### PR TITLE
Refactor IP Association

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ test: fmtcheck errcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	ORACLE_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	ORACLE_ACC=1 go test $(TEST) $(TESTARGS) -timeout 120m
 
 testrace: fmtcheck
 	ORACLE_ACC= go test -race $(TEST) $(TESTARGS)

--- a/compute/ip_associations_test.go
+++ b/compute/ip_associations_test.go
@@ -1,8 +1,9 @@
 package compute
 
 import (
-	"fmt"
 	"testing"
+
+	"log"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
 	"github.com/hashicorp/go-oracle-terraform/opc"
@@ -20,8 +21,6 @@ func TestAccIPAssociationLifeCycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//TODO: Initial Implementation
-	//createdInstanceName, err = svc.LaunchInstance("test", "test", "oc3", "/oracle/public/oel_6.4_2GB_v1", nil, nil, []string{},
 	createdInstanceName, err = svc.LaunchInstance("test", "test", "oc3", instanceImage, nil, nil, []string{},
 		map[string]interface{}{
 			"attr1": 12,
@@ -32,15 +31,13 @@ func TestAccIPAssociationLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Instance created: %#v\n", createdInstanceName)
+	log.Printf("Instance created: %#v\n", createdInstanceName)
 
-	//TODO: Initial Implementation
-	//instanceInfo, err := svc.WaitForInstanceRunning(createdInstanceName, 120)
 	instanceInfo, err := svc.WaitForInstanceRunning(createdInstanceName, 300)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Instance retrieved: %#v\n", instanceInfo)
+	log.Printf("Instance retrieved: %#v\n", instanceInfo)
 
 	vcable = instanceInfo.VCableID
 
@@ -49,34 +46,43 @@ func TestAccIPAssociationLifeCycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	createdIPAssociation, err := ipac.CreateIPAssociation(vcable, parentPool)
+	createInput := &CreateIPAssociationInput{
+		VCable:     vcable,
+		ParentPool: parentPool,
+	}
+
+	createdIPAssociation, err := ipac.CreateIPAssociation(createInput)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Created IP Association: %+v\n", createdIPAssociation)
+	log.Printf("Created IP Association: %+v\n", createdIPAssociation)
 
-	ipAssociationInfo, err := ipac.GetIPAssociation(createdIPAssociation.Name)
+	getInput := &GetIPAssociationInput{
+		Name: createdIPAssociation.Name,
+	}
+	ipAssociationInfo, err := ipac.GetIPAssociation(getInput)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if createdIPAssociation.URI != ipAssociationInfo.URI {
 		t.Fatal("IP Association URIs don't match")
 	}
-	fmt.Printf("Successfully retrived ip association\n")
+	log.Printf("Successfully retrived ip association\n")
 
-	err = ipac.DeleteIPAssociation(ipAssociationInfo.Name)
+	deleteInput := &DeleteIPAssociationInput{
+		Name: ipAssociationInfo.Name,
+	}
+	err = ipac.DeleteIPAssociation(deleteInput)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Successfully deleted IP Association\n")
+	log.Printf("Successfully deleted IP Association\n")
 
 	err = svc.DeleteInstance(createdInstanceName)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Sent Delete instance req\n")
-	//TODO: Initial Implementation
-	//err = svc.WaitForInstanceDeleted(createdInstanceName, 600)
+	log.Printf("Sent Delete instance req\n")
 	waitErr := svc.WaitForInstanceDeleted(createdInstanceName, 600)
 	if waitErr != nil {
 		panic(err)

--- a/compute/resource_client.go
+++ b/compute/resource_client.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -59,5 +60,9 @@ func (c *ResourceClient) deleteResource(name string) error {
 func (c *ResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
-	return json.Unmarshal(buf.Bytes(), iface)
+	err := json.Unmarshal(buf.Bytes(), iface)
+	if err != nil {
+		return fmt.Errorf("Error unmarshalling response body: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Refactors the IP Association resource endpoint and tests

```
$ make testacc TEST=./compute TESTARGS='-run=TestAccIPAssociationLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test ./compute -run=TestAccIPAssociationLifeCycle -timeout 120m
ok      github.com/hashicorp/go-oracle-terraform/compute        237.639s
```