### PR TITLE
Refactored Security Lists

### DIFF
--- a/compute/security_lists.go
+++ b/compute/security_lists.go
@@ -37,9 +37,7 @@ type CreateSecurityListInput struct {
 
 // CreateSecurityList creates a new security list with the given name, policy and outbound CIDR policy.
 func (c *SecurityListsClient) CreateSecurityList(createInput *CreateSecurityListInput) (*SecurityListInfo, error) {
-
 	createInput.Name = c.getQualifiedName(createInput.Name)
-
 	var listInfo SecurityListInfo
 	if err := c.createResource(createInput, &listInfo); err != nil {
 		return nil, err
@@ -74,7 +72,6 @@ type UpdateSecurityListInput struct {
 // UpdateSecurityList updates the policy and outbound CIDR pol
 func (c *SecurityListsClient) UpdateSecurityList(updateInput *UpdateSecurityListInput) (*SecurityListInfo, error) {
 	updateInput.Name = c.getQualifiedName(updateInput.Name)
-
 	var listInfo SecurityListInfo
 	if err := c.updateResource(updateInput.Name, updateInput, &listInfo); err != nil {
 		return nil, err

--- a/compute/security_lists_test.go
+++ b/compute/security_lists_test.go
@@ -18,7 +18,7 @@ func TestAccSecurityListLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Printf("Obtained Security List Client\n")
+	log.Printf("Obtained Security List Client")
 
 	createSecurityListInput := CreateSecurityListInput{
 		Name:               "test-sec-list",
@@ -29,7 +29,7 @@ func TestAccSecurityListLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Printf("Successfully created Security List: %+v\n", securityList)
+	log.Printf("Successfully created Security List: %+v", securityList)
 
 	getSecurityListInput := GetSecurityListInput{
 		Name: securityList.Name,
@@ -39,9 +39,9 @@ func TestAccSecurityListLifeCycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	if securityList.Policy != getSecurityListOutput.Policy {
-		t.Fatal("Created and retrived policies don't match %s %s\n", securityList.Policy, getSecurityListOutput.Policy)
+		t.Fatalf("Created and retrived policies don't match.\n Desired: %s\n Actual: %s", securityList.Policy, getSecurityListOutput.Policy)
 	}
-	log.Printf("Successfully retrieved Security List\n")
+	log.Printf("Successfully retrieved Security List")
 
 	updateSecurityListInput := UpdateSecurityListInput{
 		Name:               securityList.Name,
@@ -53,9 +53,9 @@ func TestAccSecurityListLifeCycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	if updateSecurityListOutput.OutboundCIDRPolicy != "PERMIT" {
-		t.Fatal("Outbound policy not successfully updated \nDesired: %s \nActual: %s", updateSecurityListInput.OutboundCIDRPolicy, updateSecurityListOutput.OutboundCIDRPolicy)
+		t.Fatalf("Outbound policy not successfully updated \nDesired: %s \nActual: %s", updateSecurityListInput.OutboundCIDRPolicy, updateSecurityListOutput.OutboundCIDRPolicy)
 	}
-	log.Printf("Successfully updated Security List\n")
+	log.Printf("Successfully updated Security List")
 
 	deleteSecurityListInput := DeleteSecurityListInput{
 		Name: securityList.Name,
@@ -64,7 +64,7 @@ func TestAccSecurityListLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Printf("Successfully deleted Security List\n")
+	log.Printf("Successfully deleted Security List")
 }
 
 // Test that the client can create an instance.


### PR DESCRIPTION
Refactors security lists to the new format. Also adds an acceptance test to confirm functionality.

```
=== RUN   TestAccSecurityListLifeCycle
2017/02/17 09:58:20 Obtained Security List Client
2017/02/17 09:58:21 Successfully created Security List: &{Account:/Compute-a431545/default Description: Name:test-sec-list OutboundCIDRPolicy:DENY Policy:PERMIT URI:https://compute.uscom-central-1.oraclecloud.com/seclist/Compute-a431545/mfrahry%40hashicorp.com/test-sec-list}
2017/02/17 09:58:23 Successfully retrieved Security List
2017/02/17 09:58:24 Successfully updated Security List
2017/02/17 09:58:25 Successfully deleted Security List
--- PASS: TestAccSecurityListLifeCycle (5.22s)
```