### PR TITLE
Use the new IP Networks resource to test vnic resources

### DIFF
--- a/compute/virtual_nic_test.go
+++ b/compute/virtual_nic_test.go
@@ -8,8 +8,21 @@ import (
 	"github.com/hashicorp/go-oracle-terraform/opc"
 )
 
+const (
+	_VirtNicInstanceTestName  = "test-acc-virt-nic"
+	_VirtNicInstanceTestLabel = "test"
+	_VirtNicInstanceTestShape = "oc3"
+	_VirtNicInstanceTestImage = "/oracle/public/Oracle_Solaris_11.3"
+)
+
 func TestAccVirtNICLifeCycle(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
+
+	ipNetwork, err := createTestIPNetwork(_IPNetworkTestPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyIPNetwork(t, ipNetwork.Name)
 
 	instanceSvc, err := getInstancesClient()
 	if err != nil {
@@ -19,18 +32,15 @@ func TestAccVirtNICLifeCycle(t *testing.T) {
 	// In order to get details on a Virtual NIC we need to create the following resources
 	// - IP Network
 	// - Instance
-	//
-	// Until we can create an IP Network resource, we are going to use one that was manually created
-	// TODO: Remove hardcoded IP Network when the IP Network resource is added
 
 	instanceInput := &CreateInstanceInput{
-		Name:      "test-acc-virt-nic-lifecycle",
-		Label:     "test",
-		Shape:     "oc3",
-		ImageList: "/oracle/public/Oracle_Solaris_11.3",
+		Name:      _VirtNicInstanceTestName,
+		Label:     _VirtNicInstanceTestLabel,
+		Shape:     _VirtNicInstanceTestShape,
+		ImageList: _VirtNicInstanceTestImage,
 		Networking: map[string]NetworkingInfo{
 			"eth0": {
-				IPNetwork: "testing-1",
+				IPNetwork: ipNetwork.Name,
 				Vnic:      "eth0",
 			},
 		},


### PR DESCRIPTION
Updates the vnic tests to use the IP Networks resource now

```
$ make testacc TEST=./compute TESTARGS='-run=TestAccVirtNICSetAddNICS'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccVirtNICSetAddNICS -timeout 120m
=== RUN   TestAccVirtNICSetAddNICS
--- PASS: TestAccVirtNICSetAddNICS (118.69s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        118.692s
```

```
$ make testacc TEST=./compute TESTARGS='-run=TestAccVirtNICLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccVirtNICLifeCycle -timeout 120m
=== RUN   TestAccVirtNICLifeCycle
--- PASS: TestAccVirtNICLifeCycle (107.20s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        107.224s
```