### PR TITLE
F add security rules

### DIFF
--- a/compute/client.go
+++ b/compute/client.go
@@ -169,6 +169,20 @@ func (c *Client) unqualify(names ...*string) {
 	}
 }
 
+func (c *Client) getQualifiedList(list []string) []string {
+	for i, name := range list {
+		list[i] = c.getQualifiedName(name)
+	}
+	return list
+}
+
+func (c *Client) getUnqualifiedList(list []string) []string {
+	for i, name := range list {
+		list[i] = c.getUnqualifiedName(name)
+	}
+	return list
+}
+
 func (c *Client) getQualifiedListName(name string) string {
 	nameParts := strings.Split(name, ":")
 	listType := nameParts[0]

--- a/compute/ip_address_prefix_set.go
+++ b/compute/ip_address_prefix_set.go
@@ -1,0 +1,135 @@
+package compute
+
+const (
+	IPAddressPrefixSetDescription   = "ip address prefix set"
+	IPAddressPrefixSetContainerPath = "/network/v1/ipaddressprefixset/"
+	IPAddressPrefixSetResourcePath  = "/network/v1/ipaddressprefixset"
+)
+
+type IPAddressPrefixSetsClient struct {
+	ResourceClient
+}
+
+// IPAddressPrefixSets() returns an IPAddressPrefixSetsClient that can be used to access the
+// necessary CRUD functions for IP Address Prefix Sets.
+func (c *Client) IPAddressPrefixSets() *IPAddressPrefixSetsClient {
+	return &IPAddressPrefixSetsClient{
+		ResourceClient: ResourceClient{
+			Client:              c,
+			ResourceDescription: IPAddressPrefixSetDescription,
+			ContainerPath:       IPAddressPrefixSetContainerPath,
+			ResourceRootPath:    IPAddressPrefixSetResourcePath,
+		},
+	}
+}
+
+// IPAddressPrefixSetInfo contains the exported fields necessary to hold all the information about an
+// IP Address Prefix Set
+type IPAddressPrefixSetInfo struct {
+	// The name of the IP Address Prefix Set
+	Name string `json:"name"`
+	// Description of the IP Address Prefix Set
+	Description string `json:"description"`
+	// List of CIDR IPv4 prefixes assigned in the virtual network.
+	IPAddressPrefixes []string `json:"ipAddressPrefixes"`
+	// Slice of tags associated with the IP Address Prefix Set
+	Tags []string `json:"tags"`
+	// Uniform Resource Identifier for the IP Address Prefix Set
+	Uri string `json:"uri"`
+}
+
+type CreateIPAddressPrefixSetInput struct {
+	// The name of the IP Address Prefix Set to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// Description of the IPAddressPrefixSet
+	// Optional
+	Description string `json:"description"`
+
+	// List of CIDR IPv4 prefixes assigned in the virtual network.
+	// Optional
+	IPAddressPrefixes []string `json:"ipAddressPrefixes"`
+
+	// String slice of tags to apply to the IP Address Prefix Set object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// Create a new IP Address Prefix Set from an IPAddressPrefixSetsClient and an input struct.
+// Returns a populated Info struct for the IP Address Prefix Set, and any errors
+func (c *IPAddressPrefixSetsClient) CreateIPAddressPrefixSet(input *CreateIPAddressPrefixSetInput) (*IPAddressPrefixSetInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+
+	var ipInfo IPAddressPrefixSetInfo
+	if err := c.createResource(&input, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type GetIPAddressPrefixSetInput struct {
+	// The name of the IP Address Prefix Set to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+// Returns a populated IPAddressPrefixSetInfo struct from an input struct
+func (c *IPAddressPrefixSetsClient) GetIPAddressPrefixSet(input *GetIPAddressPrefixSetInput) (*IPAddressPrefixSetInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+
+	var ipInfo IPAddressPrefixSetInfo
+	if err := c.getResource(input.Name, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+// UpdateIPAddressPrefixSetInput defines what to update in a ip address prefix set
+type UpdateIPAddressPrefixSetInput struct {
+	// The name of the IP Address Prefix Set to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// Description of the IPAddressPrefixSet
+	// Optional
+	Description string `json:"description"`
+
+	// List of CIDR IPv4 prefixes assigned in the virtual network.
+	IPAddressPrefixes []string `json:"ipAddressPrefixes"`
+
+	// String slice of tags to apply to the IP Address Prefix Set object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// UpdateIPAddressPrefixSet update the ip address prefix set
+func (c *IPAddressPrefixSetsClient) UpdateIPAddressPrefixSet(updateInput *UpdateIPAddressPrefixSetInput) (*IPAddressPrefixSetInfo, error) {
+	updateInput.Name = c.getQualifiedName(updateInput.Name)
+	var ipInfo IPAddressPrefixSetInfo
+	if err := c.updateResource(updateInput.Name, updateInput, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type DeleteIPAddressPrefixSetInput struct {
+	// The name of the IP Address Prefix Set to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+func (c *IPAddressPrefixSetsClient) DeleteIPAddressPrefixSet(input *DeleteIPAddressPrefixSetInput) error {
+	return c.deleteResource(input.Name)
+}
+
+// Unqualifies any qualified fields in the IPAddressPrefixSetInfo struct
+func (c *IPAddressPrefixSetsClient) success(info *IPAddressPrefixSetInfo) (*IPAddressPrefixSetInfo, error) {
+	c.unqualify(&info.Name)
+	return info, nil
+}

--- a/compute/ip_address_prefix_set_test.go
+++ b/compute/ip_address_prefix_set_test.go
@@ -1,0 +1,89 @@
+package compute
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_IPAddressPrefixSetTestName        = "test-acc-ip-address-prefix-set"
+	_IPAddressPrefixSetTestDescription = "testing ip address prefix set"
+)
+
+func TestAccIPAddressPrefixSetsLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	svc, err := getIPAddressPrefixSetsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createInput := &CreateIPAddressPrefixSetInput{
+		Name:              _IPAddressPrefixSetTestName,
+		Description:       _IPAddressPrefixSetTestDescription,
+		IPAddressPrefixes: []string{"192.0.0.168/16"},
+		Tags:              []string{"testing"},
+	}
+
+	createdIPAddressPrefixSet, err := svc.CreateIPAddressPrefixSet(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Prefix Set succcessfully created")
+	defer destroyIPAddressPrefixSet(t, svc, _IPAddressPrefixSetTestName)
+
+	getInput := &GetIPAddressPrefixSetInput{
+		Name: _IPAddressPrefixSetTestName,
+	}
+	receivedIPAddressPrefixSet, err := svc.GetIPAddressPrefixSet(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Prefix Set successfully fetched")
+
+	if !reflect.DeepEqual(createdIPAddressPrefixSet, receivedIPAddressPrefixSet) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", createdIPAddressPrefixSet, receivedIPAddressPrefixSet)
+	}
+
+	updateInput := &UpdateIPAddressPrefixSetInput{
+		Name:              _IPAddressPrefixSetTestName,
+		Description:       _IPAddressPrefixSetTestDescription,
+		IPAddressPrefixes: []string{"192.0.0.167/16"},
+		Tags:              []string{"testing"},
+	}
+	updatedIPAddressPrefixSet, err := svc.UpdateIPAddressPrefixSet(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Prefix Set succcessfully updated")
+	receivedIPAddressPrefixSet, err = svc.GetIPAddressPrefixSet(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(updatedIPAddressPrefixSet, receivedIPAddressPrefixSet) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", updatedIPAddressPrefixSet, receivedIPAddressPrefixSet)
+	}
+}
+
+func destroyIPAddressPrefixSet(t *testing.T, svc *IPAddressPrefixSetsClient, name string) {
+	input := &DeleteIPAddressPrefixSetInput{
+		Name: name,
+	}
+	if err := svc.DeleteIPAddressPrefixSet(input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getIPAddressPrefixSetsClient() (*IPAddressPrefixSetsClient, error) {
+	client, err := getTestClient(&opc.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.IPAddressPrefixSets(), nil
+}

--- a/compute/security_protocols.go
+++ b/compute/security_protocols.go
@@ -1,0 +1,187 @@
+package compute
+
+const (
+	SecurityProtocolDescription   = "security protocol"
+	SecurityProtocolContainerPath = "/network/v1/secprotocol/"
+	SecurityProtocolResourcePath  = "/network/v1/secprotocol"
+)
+
+type SecurityProtocolsClient struct {
+	ResourceClient
+}
+
+// SecurityProtocols() returns an SecurityProtocolsClient that can be used to access the
+// necessary CRUD functions for Security Protocols.
+func (c *Client) SecurityProtocols() *SecurityProtocolsClient {
+	return &SecurityProtocolsClient{
+		ResourceClient: ResourceClient{
+			Client:              c,
+			ResourceDescription: SecurityProtocolDescription,
+			ContainerPath:       SecurityProtocolContainerPath,
+			ResourceRootPath:    SecurityProtocolResourcePath,
+		},
+	}
+}
+
+// SecurityProtocolInfo contains the exported fields necessary to hold all the information about an
+// Security Protocol
+type SecurityProtocolInfo struct {
+	// List of port numbers or port range strings to match the packet's destination port.
+	DstPortSet []string `json:"dstPortSet"`
+	// Protocol used in the data portion of the IP datagram.
+	IPProtocol string `json:"ipProtocol"`
+	// List of port numbers or port range strings to match the packet's source port.
+	SrcPortSet []string `json:"srcPortSet"`
+	// The name of the Security Protocol
+	Name string `json:"name"`
+	// Description of the Security Protocol
+	Description string `json:"description"`
+	// Slice of tags associated with the Security Protocol
+	Tags []string `json:"tags"`
+	// Uniform Resource Identifier for the Security Protocol
+	Uri string `json:"uri"`
+}
+
+type CreateSecurityProtocolInput struct {
+	// The name of the Security Protocol to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// Description of the SecurityProtocol
+	// Optional
+	Description string `json:"description"`
+
+	// Enter a list of port numbers or port range strings.
+	//Traffic is enabled by a security rule when a packet's destination port matches the
+	// ports specified here.
+	// For TCP, SCTP, and UDP, each port is a destination transport port, between 0 and 65535,
+	// inclusive. For ICMP, each port is an ICMP type, between 0 and 255, inclusive.
+	// If no destination ports are specified, all destination ports or ICMP types are allowed.
+	// Optional
+	DstPortSet []string `json:"dstPortSet"`
+
+	// The protocol used in the data portion of the IP datagram.
+	// Specify one of the permitted values or enter a number in the range 0–254 to
+	// represent the protocol that you want to specify. See Assigned Internet Protocol Numbers.
+	// Permitted values are: tcp, udp, icmp, igmp, ipip, rdp, esp, ah, gre, icmpv6, ospf, pim, sctp,
+	// mplsip, all.
+	// Traffic is enabled by a security rule when the protocol in the packet matches the
+	// protocol specified here. If no protocol is specified, all protocols are allowed.
+	// Optional
+	IPProtocol string `json:"ipProtocol"`
+
+	// Enter a list of port numbers or port range strings.
+	// Traffic is enabled by a security rule when a packet's source port matches the
+	// ports specified here.
+	// For TCP, SCTP, and UDP, each port is a source transport port,
+	// between 0 and 65535, inclusive.
+	// For ICMP, each port is an ICMP type, between 0 and 255, inclusive.
+	// If no source ports are specified, all source ports or ICMP types are allowed.
+	// Optional
+	SrcPortSet []string `json:"srcPortSet"`
+
+	// String slice of tags to apply to the Security Protocol object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// Create a new Security Protocol from an SecurityProtocolsClient and an input struct.
+// Returns a populated Info struct for the Security Protocol, and any errors
+func (c *SecurityProtocolsClient) CreateSecurityProtocol(input *CreateSecurityProtocolInput) (*SecurityProtocolInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+
+	var ipInfo SecurityProtocolInfo
+	if err := c.createResource(&input, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type GetSecurityProtocolInput struct {
+	// The name of the Security Protocol to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+// Returns a populated SecurityProtocolInfo struct from an input struct
+func (c *SecurityProtocolsClient) GetSecurityProtocol(input *GetSecurityProtocolInput) (*SecurityProtocolInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+
+	var ipInfo SecurityProtocolInfo
+	if err := c.getResource(input.Name, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+// UpdateSecurityProtocolInput defines what to update in a security protocol
+type UpdateSecurityProtocolInput struct {
+	// The name of the Security Protocol to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// Description of the SecurityProtocol
+	// Optional
+	Description string `json:"description"`
+
+	// Enter a list of port numbers or port range strings.
+	//Traffic is enabled by a security rule when a packet's destination port matches the
+	// ports specified here.
+	// For TCP, SCTP, and UDP, each port is a destination transport port, between 0 and 65535,
+	// inclusive. For ICMP, each port is an ICMP type, between 0 and 255, inclusive.
+	// If no destination ports are specified, all destination ports or ICMP types are allowed.
+	DstPortSet []string `json:"dstPortSet"`
+
+	// The protocol used in the data portion of the IP datagram.
+	// Specify one of the permitted values or enter a number in the range 0–254 to
+	// represent the protocol that you want to specify. See Assigned Internet Protocol Numbers.
+	// Permitted values are: tcp, udp, icmp, igmp, ipip, rdp, esp, ah, gre, icmpv6, ospf, pim, sctp,
+	// mplsip, all.
+	// Traffic is enabled by a security rule when the protocol in the packet matches the
+	// protocol specified here. If no protocol is specified, all protocols are allowed.
+	IPProtocol string `json:"ipProtocol"`
+
+	// Enter a list of port numbers or port range strings.
+	// Traffic is enabled by a security rule when a packet's source port matches the
+	// ports specified here.
+	// For TCP, SCTP, and UDP, each port is a source transport port,
+	// between 0 and 65535, inclusive.
+	// For ICMP, each port is an ICMP type, between 0 and 255, inclusive.
+	// If no source ports are specified, all source ports or ICMP types are allowed.
+	SrcPortSet []string `json:"srcPortSet"`
+
+	// String slice of tags to apply to the Security Protocol object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// UpdateSecurityProtocol update the security protocol
+func (c *SecurityProtocolsClient) UpdateSecurityProtocol(updateInput *UpdateSecurityProtocolInput) (*SecurityProtocolInfo, error) {
+	updateInput.Name = c.getQualifiedName(updateInput.Name)
+	var ipInfo SecurityProtocolInfo
+	if err := c.updateResource(updateInput.Name, updateInput, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type DeleteSecurityProtocolInput struct {
+	// The name of the Security Protocol to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+func (c *SecurityProtocolsClient) DeleteSecurityProtocol(input *DeleteSecurityProtocolInput) error {
+	return c.deleteResource(input.Name)
+}
+
+// Unqualifies any qualified fields in the SecurityProtocolInfo struct
+func (c *SecurityProtocolsClient) success(info *SecurityProtocolInfo) (*SecurityProtocolInfo, error) {
+	c.unqualify(&info.Name)
+	return info, nil
+}

--- a/compute/security_protocols_test.go
+++ b/compute/security_protocols_test.go
@@ -1,0 +1,94 @@
+package compute
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_SecurityProtocolTestName        = "test-acc-security-protocol"
+	_SecurityProtocolTestDescription = "testing security protocol"
+	_SecurityProtocolTestIPProtocol  = "tcp"
+)
+
+func TestAccSecurityProtocolsLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	svc, err := getSecurityProtocolsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createInput := &CreateSecurityProtocolInput{
+		Name:        _SecurityProtocolTestName,
+		Description: _SecurityProtocolTestDescription,
+		Tags:        []string{"testing"},
+		IPProtocol:  _SecurityProtocolTestIPProtocol,
+		SrcPortSet:  []string{"17"},
+		DstPortSet:  []string{"18"},
+	}
+
+	createdSecurityProtocol, err := svc.CreateSecurityProtocol(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Protocol succcessfully created")
+	defer destroySecurityProtocol(t, svc, _SecurityProtocolTestName)
+
+	getInput := &GetSecurityProtocolInput{
+		Name: _SecurityProtocolTestName,
+	}
+	receivedSecurityProtocol, err := svc.GetSecurityProtocol(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Protocol successfully fetched")
+
+	if !reflect.DeepEqual(createdSecurityProtocol, receivedSecurityProtocol) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", createdSecurityProtocol, receivedSecurityProtocol)
+	}
+
+	updateInput := &UpdateSecurityProtocolInput{
+		Name:        _SecurityProtocolTestName,
+		Description: _SecurityProtocolTestDescription,
+		Tags:        []string{"testing"},
+		IPProtocol:  _SecurityProtocolTestIPProtocol,
+		SrcPortSet:  []string{"20"},
+		DstPortSet:  []string{"21"},
+	}
+	updatedSecurityProtocol, err := svc.UpdateSecurityProtocol(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Protocol succcessfully updated")
+	receivedSecurityProtocol, err = svc.GetSecurityProtocol(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(updatedSecurityProtocol, receivedSecurityProtocol) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", updatedSecurityProtocol, receivedSecurityProtocol)
+	}
+}
+
+func destroySecurityProtocol(t *testing.T, svc *SecurityProtocolsClient, name string) {
+	input := &DeleteSecurityProtocolInput{
+		Name: name,
+	}
+	if err := svc.DeleteSecurityProtocol(input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getSecurityProtocolsClient() (*SecurityProtocolsClient, error) {
+	client, err := getTestClient(&opc.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.SecurityProtocols(), nil
+}

--- a/compute/security_rules.go
+++ b/compute/security_rules.go
@@ -26,106 +26,111 @@ func (c *Client) SecurityRules() *SecurityRuleClient {
 // SecurityRuleInfo contains the exported fields necessary to hold all the information about a
 // Security Rule
 type SecurityRuleInfo struct {
-  // Name of the ACL that contains this rule.
-  ACL string `json:acl`
-  // Description of the Security Rule
-  Description string `json:"description"`
-  // List of IP address prefix set names to match the packet's destination IP address.
-  DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
-  // Name of virtual NIC set containing the packet's destination virtual NIC.
-  DstVnicSet string `json:"dstVnicSet"`
-  // Allows the security rule to be disabled.
-  Enabled bool `json:"enabledFlag"`
-  // Direction of the flow; Can be "egress" or "ingress".
-  FlowDirection string `json:"FlowDirection"`
-  // The name of the Security Rule
-  Name string `json:"name"`
-  // List of security protocol names to match the packet's protocol and port.
-  SecProtocols []string `json:"secProtocols"`
-  // List of multipart names of IP address prefix set to match the packet's source IP address.
-  SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
-  // Name of virtual NIC set containing the packet's source virtual NIC.
-  SrcVnicSet string `json:"srcVnicSet"`
-  // Slice of tags associated with the Security Rule
+	// Name of the ACL that contains this rule.
+	ACL string `json:acl`
+	// Description of the Security Rule
+	Description string `json:"description"`
+	// List of IP address prefix set names to match the packet's destination IP address.
+	DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
+	// Name of virtual NIC set containing the packet's destination virtual NIC.
+	DstVnicSet string `json:"dstVnicSet"`
+	// Allows the security rule to be disabled.
+	Enabled bool `json:"enabledFlag"`
+	// Direction of the flow; Can be "egress" or "ingress".
+	FlowDirection string `json:"FlowDirection"`
+	// The name of the Security Rule
+	Name string `json:"name"`
+	// List of security protocol names to match the packet's protocol and port.
+	SecProtocols []string `json:"secProtocols"`
+	// List of multipart names of IP address prefix set to match the packet's source IP address.
+	SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
+	// Name of virtual NIC set containing the packet's source virtual NIC.
+	SrcVnicSet string `json:"srcVnicSet"`
+	// Slice of tags associated with the Security Rule
 	Tags []string `json:"tags"`
 	// Uniform Resource Identifier for the Security Rule
 	Uri string `json:"uri"`
 }
 
 type CreateSecurityRuleInput struct {
-  //Select the name of the access control list (ACL) that you want to add this
-  // security rule to. Security rules are applied to vNIC sets by using ACLs.
-  // Optional
-  Acl string `json:"acl"`
+	//Select the name of the access control list (ACL) that you want to add this
+	// security rule to. Security rules are applied to vNIC sets by using ACLs.
+	// Optional
+	ACL string `json:"acl"`
 
-  // Description of the Security Rule
-  // Optional
-  Description string `json:"description"`
+	// Description of the Security Rule
+	// Optional
+	Description string `json:"description"`
 
-  // A list of IP address prefix sets to which you want to permit traffic.
-  // Only packets to IP addresses in the specified IP address prefix sets are permitted.
-  // When no destination IP address prefix sets are specified, traffic to any
-  // IP address is permitted.
-  // Optional
-  DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
+	// A list of IP address prefix sets to which you want to permit traffic.
+	// Only packets to IP addresses in the specified IP address prefix sets are permitted.
+	// When no destination IP address prefix sets are specified, traffic to any
+	// IP address is permitted.
+	// Optional
+	DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
 
-  // The vNICset to which you want to permit traffic. Only packets to vNICs in the
-  // specified vNICset are permitted. When no destination vNICset is specified, traffic
-  // to any vNIC is permitted.
-  // Optional
-  DstVnicSet string `json:"dstVnicSet"`
+	// The vNICset to which you want to permit traffic. Only packets to vNICs in the
+	// specified vNICset are permitted. When no destination vNICset is specified, traffic
+	// to any vNIC is permitted.
+	// Optional
+	DstVnicSet string `json:"dstVnicSet,omitempty"`
 
-  // Allows the security rule to be enabled or disabled. This parameter is set to
-  // true by default. Specify false to disable the security rule.
-  // Optional
-  Enabled bool `json:"enabledFlag"`
+	// Allows the security rule to be enabled or disabled. This parameter is set to
+	// true by default. Specify false to disable the security rule.
+	// Optional
+	Enabled bool `json:"enabledFlag"`
 
-  // Specify the direction of flow of traffic, which is relative to the instances,
-  // for this security rule. Allowed values are ingress or egress.
-  // An ingress packet is a packet received by a virtual NIC, for example from
-  // another virtual NIC or from the public Internet.
-  // An egress packet is a packet sent by a virtual NIC, for example to another
-  // virtual NIC or to the public Internet.
-  // Required
-  FlowDirection string `json:"FlowDirection"`
+	// Specify the direction of flow of traffic, which is relative to the instances,
+	// for this security rule. Allowed values are ingress or egress.
+	// An ingress packet is a packet received by a virtual NIC, for example from
+	// another virtual NIC or from the public Internet.
+	// An egress packet is a packet sent by a virtual NIC, for example to another
+	// virtual NIC or to the public Internet.
+	// Required
+	FlowDirection string `json:"flowDirection"`
 
-  // The name of the Security Rule
-  // Object names can contain only alphanumeric characters, hyphens, underscores, and periods.
-  // Object names are case-sensitive. When you specify the object name, ensure that an object
-  // of the same type and with the same name doesn't already exist.
-  // If such an object already exists, another object of the same type and with the same name won't
-  // be created and the existing object won't be updated.
-  // Required
-  Name string `json:"name"`
+	// The name of the Security Rule
+	// Object names can contain only alphanumeric characters, hyphens, underscores, and periods.
+	// Object names are case-sensitive. When you specify the object name, ensure that an object
+	// of the same type and with the same name doesn't already exist.
+	// If such an object already exists, another object of the same type and with the same name won't
+	// be created and the existing object won't be updated.
+	// Required
+	Name string `json:"name"`
 
-  // A list of security protocols for which you want to permit traffic. Only packets that
-  // match the specified protocols and ports are permitted. When no security protocols are
-  // specified, traffic using any protocol over any port is permitted.
-  // Optional
-  SecProtocols []string `json:"secProtocols"`
+	// A list of security protocols for which you want to permit traffic. Only packets that
+	// match the specified protocols and ports are permitted. When no security protocols are
+	// specified, traffic using any protocol over any port is permitted.
+	// Optional
+	SecProtocols []string `json:"secProtocols"`
 
-  // A list of IP address prefix sets from which you want to permit traffic. Only packets
-  // from IP addresses in the specified IP address prefix sets are permitted. When no source
-  // IP address prefix sets are specified, traffic from any IP address is permitted.
-  // Optional
-  SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
+	// A list of IP address prefix sets from which you want to permit traffic. Only packets
+	// from IP addresses in the specified IP address prefix sets are permitted. When no source
+	// IP address prefix sets are specified, traffic from any IP address is permitted.
+	// Optional
+	SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
 
-  // The vNICset from which you want to permit traffic. Only packets from vNICs in the
-  // specified vNICset are permitted. When no source vNICset is specified, traffic from any
-  // vNIC is permitted.
-  // Optional
-  SrcVnicSet string `json:"srcVnicSet"`
+	// The vNICset from which you want to permit traffic. Only packets from vNICs in the
+	// specified vNICset are permitted. When no source vNICset is specified, traffic from any
+	// vNIC is permitted.
+	// Optional
+	SrcVnicSet string `json:"srcVnicSet,omitempty"`
 
-  // Strings that you can use to tag the security rule.
-  // Optional
-  Tags []string `json:"tags"`
+	// Strings that you can use to tag the security rule.
+	// Optional
+	Tags []string `json:"tags"`
 }
 
 // Create a new Security Rule from an SecurityRuleClient and an input struct.
 // Returns a populated Info struct for the Security Rule, and any errors
 func (c *SecurityRuleClient) CreateSecurityRule(input *CreateSecurityRuleInput) (*SecurityRuleInfo, error) {
 	input.Name = c.getQualifiedName(input.Name)
-  input.Acl = c.getQualifiedName(input.Acl)
+	input.ACL = c.getQualifiedName(input.ACL)
+	input.SrcVnicSet = c.getQualifiedName(input.SrcVnicSet)
+	input.DstVnicSet = c.getQualifiedName(input.DstVnicSet)
+	input.SrcIpAddressPrefixSets = c.getQualifiedList(input.SrcIpAddressPrefixSets)
+	input.DstIpAddressPrefixSets = c.getQualifiedList(input.DstIpAddressPrefixSets)
+	input.SecProtocols = c.getQualifiedList(input.SecProtocols)
 
 	var securityRuleInfo SecurityRuleInfo
 	if err := c.createResource(&input, &securityRuleInfo); err != nil {
@@ -155,85 +160,90 @@ func (c *SecurityRuleClient) GetSecurityRule(input *GetSecurityRuleInput) (*Secu
 
 // UpdateSecurityRuleInput describes a secruity rule to update
 type UpdateSecurityRuleInput struct {
-  //Select the name of the access control list (ACL) that you want to add this
-  // security rule to. Security rules are applied to vNIC sets by using ACLs.
-  // Optional
-  Acl string `json:"acl"`
+	//Select the name of the access control list (ACL) that you want to add this
+	// security rule to. Security rules are applied to vNIC sets by using ACLs.
+	// Optional
+	ACL string `json:"acl"`
 
-  // Description of the Security Rule
-  // Optional
-  Description string `json:"description"`
+	// Description of the Security Rule
+	// Optional
+	Description string `json:"description"`
 
-  // A list of IP address prefix sets to which you want to permit traffic.
-  // Only packets to IP addresses in the specified IP address prefix sets are permitted.
-  // When no destination IP address prefix sets are specified, traffic to any
-  // IP address is permitted.
-  // Optional
-  DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
+	// A list of IP address prefix sets to which you want to permit traffic.
+	// Only packets to IP addresses in the specified IP address prefix sets are permitted.
+	// When no destination IP address prefix sets are specified, traffic to any
+	// IP address is permitted.
+	// Optional
+	DstIpAddressPrefixSets []string `json:"dstIpAddressPrefixSets"`
 
-  // The vNICset to which you want to permit traffic. Only packets to vNICs in the
-  // specified vNICset are permitted. When no destination vNICset is specified, traffic
-  // to any vNIC is permitted.
-  // Optional
-  DstVnicSet string `json:"dstVnicSet"`
+	// The vNICset to which you want to permit traffic. Only packets to vNICs in the
+	// specified vNICset are permitted. When no destination vNICset is specified, traffic
+	// to any vNIC is permitted.
+	// Optional
+	DstVnicSet string `json:"dstVnicSet,omitempty"`
 
-  // Allows the security rule to be enabled or disabled. This parameter is set to
-  // true by default. Specify false to disable the security rule.
-  // Optional
-  Enabled bool `json:"enabledFlag"`
+	// Allows the security rule to be enabled or disabled. This parameter is set to
+	// true by default. Specify false to disable the security rule.
+	// Optional
+	Enabled bool `json:"enabledFlag"`
 
-  // Specify the direction of flow of traffic, which is relative to the instances,
-  // for this security rule. Allowed values are ingress or egress.
-  // An ingress packet is a packet received by a virtual NIC, for example from
-  // another virtual NIC or from the public Internet.
-  // An egress packet is a packet sent by a virtual NIC, for example to another
-  // virtual NIC or to the public Internet.
-  // Required
-  FlowDirection string `json:"FlowDirection"`
+	// Specify the direction of flow of traffic, which is relative to the instances,
+	// for this security rule. Allowed values are ingress or egress.
+	// An ingress packet is a packet received by a virtual NIC, for example from
+	// another virtual NIC or from the public Internet.
+	// An egress packet is a packet sent by a virtual NIC, for example to another
+	// virtual NIC or to the public Internet.
+	// Required
+	FlowDirection string `json:"flowDirection"`
 
-  // The name of the Security Rule
-  // Object names can contain only alphanumeric characters, hyphens, underscores, and periods.
-  // Object names are case-sensitive. When you specify the object name, ensure that an object
-  // of the same type and with the same name doesn't already exist.
-  // If such an object already exists, another object of the same type and with the same name won't
-  // be created and the existing object won't be updated.
-  // Required
-  Name string `json:"name"`
+	// The name of the Security Rule
+	// Object names can contain only alphanumeric characters, hyphens, underscores, and periods.
+	// Object names are case-sensitive. When you specify the object name, ensure that an object
+	// of the same type and with the same name doesn't already exist.
+	// If such an object already exists, another object of the same type and with the same name won't
+	// be created and the existing object won't be updated.
+	// Required
+	Name string `json:"name"`
 
-  // A list of security protocols for which you want to permit traffic. Only packets that
-  // match the specified protocols and ports are permitted. When no security protocols are
-  // specified, traffic using any protocol over any port is permitted.
-  // Optional
-  SecProtocols []string `json:"secProtocols"`
+	// A list of security protocols for which you want to permit traffic. Only packets that
+	// match the specified protocols and ports are permitted. When no security protocols are
+	// specified, traffic using any protocol over any port is permitted.
+	// Optional
+	SecProtocols []string `json:"secProtocols"`
 
-  // A list of IP address prefix sets from which you want to permit traffic. Only packets
-  // from IP addresses in the specified IP address prefix sets are permitted. When no source
-  // IP address prefix sets are specified, traffic from any IP address is permitted.
-  // Optional
-  SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
+	// A list of IP address prefix sets from which you want to permit traffic. Only packets
+	// from IP addresses in the specified IP address prefix sets are permitted. When no source
+	// IP address prefix sets are specified, traffic from any IP address is permitted.
+	// Optional
+	SrcIpAddressPrefixSets []string `json:"srcIpAddressPrefixSets"`
 
-  // The vNICset from which you want to permit traffic. Only packets from vNICs in the
-  // specified vNICset are permitted. When no source vNICset is specified, traffic from any
-  // vNIC is permitted.
-  // Optional
-  SrcVnicSet string `json:"srcVnicSet"`
+	// The vNICset from which you want to permit traffic. Only packets from vNICs in the
+	// specified vNICset are permitted. When no source vNICset is specified, traffic from any
+	// vNIC is permitted.
+	// Optional
+	SrcVnicSet string `json:"srcVnicSet,omitempty"`
 
-  // Strings that you can use to tag the security rule.
-  // Optional
-  Tags []string `json:"tags"`
+	// Strings that you can use to tag the security rule.
+	// Optional
+	Tags []string `json:"tags"`
 }
 
 // UpdateSecRule modifies the properties of the sec rule with the given name.
-func (c *SecurityRulesClient) UpdateSecurityRule(updateInput *UpdateSecurityRuleInput) (*SecurityRuleInfo, error) {
+func (c *SecurityRuleClient) UpdateSecurityRule(updateInput *UpdateSecurityRuleInput) (*SecurityRuleInfo, error) {
 	updateInput.Name = c.getQualifiedName(updateInput.Name)
-  input.Acl = c.getQualifiedName(input.Acl)
+	updateInput.ACL = c.getQualifiedName(updateInput.ACL)
+	updateInput.SrcVnicSet = c.getQualifiedName(updateInput.SrcVnicSet)
+	updateInput.DstVnicSet = c.getQualifiedName(updateInput.DstVnicSet)
+	updateInput.SrcIpAddressPrefixSets = c.getQualifiedList(updateInput.SrcIpAddressPrefixSets)
+	updateInput.DstIpAddressPrefixSets = c.getQualifiedList(updateInput.DstIpAddressPrefixSets)
+	updateInput.SecProtocols = c.getQualifiedList(updateInput.SecProtocols)
 
 	var securityRuleInfo SecurityRuleInfo
 	if err := c.updateResource(updateInput.Name, updateInput, &securityRuleInfo); err != nil {
 		return nil, err
 	}
 
-	return c.success(&ruleInfo)
+	return c.success(&securityRuleInfo)
 }
 
 type DeleteSecurityRuleInput struct {
@@ -248,6 +258,9 @@ func (c *SecurityRuleClient) DeleteSecurityRule(input *DeleteSecurityRuleInput) 
 
 // Unqualifies any qualified fields in the IPNetworkExchangeInfo struct
 func (c *SecurityRuleClient) success(info *SecurityRuleInfo) (*SecurityRuleInfo, error) {
-	c.unqualify(&info.Name)
+	c.unqualify(&info.Name, &info.ACL, &info.SrcVnicSet, &info.DstVnicSet)
+	info.SrcIpAddressPrefixSets = c.getUnqualifiedList(info.SrcIpAddressPrefixSets)
+	info.DstIpAddressPrefixSets = c.getUnqualifiedList(info.DstIpAddressPrefixSets)
+	info.SecProtocols = c.getUnqualifiedList(info.SecProtocols)
 	return info, nil
 }

--- a/compute/security_rules_test.go
+++ b/compute/security_rules_test.go
@@ -1,0 +1,211 @@
+package compute
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_SecurityRuleTestName        = "test-acc-security-rule"
+	_SecurityRuleTestDescription = "testing security rule"
+	_SecurityRuleFlowDirection   = "ingress"
+)
+
+func TestAccSecurityRulesLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	svc, err := getSecurityRulesClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createInput := &CreateSecurityRuleInput{
+		Name:          _SecurityRuleTestName,
+		Description:   _SecurityRuleTestDescription,
+		FlowDirection: _SecurityRuleFlowDirection,
+		Tags:          []string{"testing"},
+	}
+
+	createdRule, err := svc.CreateSecurityRule(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Rule succcessfully created")
+	defer destroySecurityRule(t, svc, _SecurityRuleTestName)
+
+	getInput := &GetSecurityRuleInput{
+		Name: _SecurityRuleTestName,
+	}
+	receivedRule, err := svc.GetSecurityRule(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Rule successfully fetched")
+
+	if !reflect.DeepEqual(createdRule.Tags, receivedRule.Tags) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", createdRule, receivedRule)
+	}
+
+	// Update prefix, NAPT, and tags
+	updateInput := &UpdateSecurityRuleInput{
+		Name:          _SecurityRuleTestName,
+		Description:   _SecurityRuleTestDescription,
+		FlowDirection: _SecurityRuleFlowDirection,
+		Tags:          []string{"updated"},
+	}
+
+	updatedRule, err := svc.UpdateSecurityRule(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Rule successfully updated")
+
+	receivedRule, err = svc.GetSecurityRule(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Rule successfully fetched")
+
+	if !reflect.DeepEqual(updatedRule.Tags, receivedRule.Tags) {
+		t.Fatalf("Mismatch found after update.\nExpected: %+v\nReceived: %+v", createdRule, receivedRule)
+	}
+}
+
+func TestAccSecurityRulesWithOptionsLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	ssc, err := getVirtNICSetsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstInput := &CreateVirtualNICSetInput{
+		Name:        _SecurityRuleTestName + "dst_set",
+		Description: _SecurityRuleTestDescription,
+	}
+
+	dstSet, err := ssc.CreateVirtualNICSet(dstInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteVirtualNICSet(t, ssc, dstSet.Name)
+	log.Printf("Created NIC Set: %#v", dstSet)
+
+	srcInput := &CreateVirtualNICSetInput{
+		Name:        _SecurityRuleTestName + "src_set",
+		Description: _SecurityRuleTestDescription,
+	}
+	srcSet, err := ssc.CreateVirtualNICSet(srcInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteVirtualNICSet(t, ssc, srcSet.Name)
+	log.Printf("Created NIC Set: %#v", srcSet)
+
+	spc, err := getSecurityProtocolsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createSecurityProtocolInput := &CreateSecurityProtocolInput{
+		Name:        _SecurityProtocolTestName,
+		Description: _SecurityProtocolTestDescription,
+		Tags:        []string{"testing"},
+		IPProtocol:  _SecurityProtocolTestIPProtocol,
+		SrcPortSet:  []string{"17"},
+		DstPortSet:  []string{"18"},
+	}
+
+	createdSecurityProtocol, err := spc.CreateSecurityProtocol(createSecurityProtocolInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Protocol succcessfully created")
+	defer destroySecurityProtocol(t, spc, _SecurityProtocolTestName)
+
+	svc, err := getSecurityRulesClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sic, err := getIPAddressPrefixSetsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstIPAddressPrefixSetInput := &CreateIPAddressPrefixSetInput{
+		Name:              _IPAddressPrefixSetTestName + "-dst",
+		Description:       _IPAddressPrefixSetTestDescription,
+		IPAddressPrefixes: []string{"192.0.0.168/16"},
+		Tags:              []string{"testing"},
+	}
+
+	dstIPAddressPrefixSet, err := sic.CreateIPAddressPrefixSet(dstIPAddressPrefixSetInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Dst IP Address Prefix Set succcessfully created")
+	defer destroyIPAddressPrefixSet(t, sic, dstIPAddressPrefixSet.Name)
+
+	srcIPAddressPrefixSetInput := &CreateIPAddressPrefixSetInput{
+		Name:              _IPAddressPrefixSetTestName + "-src",
+		Description:       _IPAddressPrefixSetTestDescription,
+		IPAddressPrefixes: []string{"192.0.0.169/16"},
+		Tags:              []string{"testing"},
+	}
+
+	srcIPAddressPrefixSet, err := sic.CreateIPAddressPrefixSet(srcIPAddressPrefixSetInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Src IP Address Prefix Set succcessfully created")
+	defer destroyIPAddressPrefixSet(t, sic, srcIPAddressPrefixSet.Name)
+
+	createInput := &CreateSecurityRuleInput{
+		Name:                   _SecurityRuleTestName,
+		Description:            _SecurityRuleTestDescription,
+		DstVnicSet:             dstSet.Name,
+		SrcVnicSet:             srcSet.Name,
+		DstIpAddressPrefixSets: []string{dstIPAddressPrefixSet.Name},
+		SrcIpAddressPrefixSets: []string{srcIPAddressPrefixSet.Name},
+		SecProtocols:           []string{createdSecurityProtocol.Name},
+		FlowDirection:          _SecurityRuleFlowDirection,
+		Tags:                   []string{"testing"},
+	}
+
+	createdRule, err := svc.CreateSecurityRule(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("Security Rule succcessfully created")
+	defer destroySecurityRule(t, svc, _SecurityRuleTestName)
+
+	if dstSet.Name != createdRule.DstVnicSet {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", dstSet.Name, createdRule.DstVnicSet)
+	}
+	if srcSet.Name != createdRule.SrcVnicSet {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", dstSet.Name, createdRule.DstVnicSet)
+	}
+}
+
+func destroySecurityRule(t *testing.T, svc *SecurityRuleClient, name string) {
+	input := &DeleteSecurityRuleInput{
+		Name: name,
+	}
+	if err := svc.DeleteSecurityRule(input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getSecurityRulesClient() (*SecurityRuleClient, error) {
+	client, err := getTestClient(&opc.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.SecurityRules(), nil
+}


### PR DESCRIPTION
Adds Security Rules, IP Address Prefix Sets, and Security Protocols.
```
make testacc TEST=./compute TESTARGS='-run=TestAccSecurityRules'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccSecurityRules -timeout 120m
=== RUN   TestAccSecurityRulesLifeCycle
--- PASS: TestAccSecurityRulesLifeCycle (5.26s)
=== RUN   TestAccSecurityRulesWithOptionsLifeCycle
--- PASS: TestAccSecurityRulesWithOptionsLifeCycle (16.28s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	21.572s
```
```
make testacc TEST=./compute TESTARGS='-run=TestAccSecurityProtocols'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccSecurityProtocols -timeout 120m
=== RUN   TestAccSecurityProtocolsLifeCycle
--- PASS: TestAccSecurityProtocolsLifeCycle (3.70s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	3.725s
```
```
make testacc TEST=./compute TESTARGS='-run=TestAccIPAddressPrefix'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccIPAddressPrefix -timeout 120m
=== RUN   TestAccIPAddressPrefixSetsLifeCycle
--- PASS: TestAccIPAddressPrefixSetsLifeCycle (3.78s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	3.812s
```