### PR TITLE
Instances: unqualifying the name

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -243,7 +243,7 @@ func (c *InstancesClient) GetInstance(input *GetInstanceInput) (*InstanceInfo, e
 
 	// Overwrite returned name/ID with known name/ID
 	// Otherwise the returned name will be the fully qualified name, and the ID will be blank
-	responseBody.Name = input.Name
+	responseBody.Name = c.getUnqualifiedName(input.Name)
 	responseBody.ID = input.ID
 
 	c.unqualify(&responseBody.VCableID)

--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -78,14 +78,19 @@ func TestInstanceClient_CreateInstance(t *testing.T) {
 		},
 	}
 
-	id, err := iv.CreateInstance(input)
+	created, err := iv.CreateInstance(input)
 	if err != nil {
 		t.Fatalf("Create instance request failed: %s", err)
 	}
 
-	expected := "437b72fd-b870-47b1-9c01-7a2812bbe30c"
-	if id.ID != expected {
-		t.Errorf("Expected id %s, was %s", expected, id.ID)
+	expectedId := "437b72fd-b870-47b1-9c01-7a2812bbe30c"
+	if created.ID != expectedId {
+		t.Errorf("Expected id %s, was %s", expectedId, created.ID)
+	}
+
+	expectedName := "name"
+	if created.Name != expectedName {
+		t.Errorf("Expected name %s, was %s", expectedName, created.Name)
 	}
 }
 
@@ -123,6 +128,11 @@ func TestInstanceClient_RetrieveInstance(t *testing.T) {
 	}
 	if info.SSHKeys[0] != "acme-prod-admin" {
 		t.Errorf("Expected ssh key 'acme-prod-admin', was %s", info.SSHKeys[0])
+	}
+
+	expectedName := "test-instance"
+	if info.Name != expectedName {
+		t.Errorf("Expected name %s, was %s", expectedName, info.Name)
 	}
 }
 


### PR DESCRIPTION
Tests pass:

```
envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestInstance'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestInstance -timeout 120m
=== RUN   TestInstanceClient_CreateInstance
--- PASS: TestInstanceClient_CreateInstance (1.01s)
=== RUN   TestInstanceClient_RetrieveInstance
--- PASS: TestInstanceClient_RetrieveInstance (0.00s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	1.024s

$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccInstanceLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccInstanceLifeCycle -timeout 120m
=== RUN   TestAccInstanceLifeCycle
--- PASS: TestAccInstanceLifeCycle (268.17s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	268.185s
```