### PR TITLE
Qualifying the Security Associations Name

### DIFF
--- a/compute/security_associations.go
+++ b/compute/security_associations.go
@@ -34,7 +34,7 @@ type CreateSecurityAssociationInput struct {
 	// The three-part name of the Security Association (/Compute-identity_domain/user/object).
 	// If you don't specify a name for this object, then the name is generated automatically.
 	// Object names can contain only alphanumeric characters, hyphens, underscores, and periods. Object names are case-sensitive.
-	// Required
+	// Optional
 	Name string `json:"name"`
 	// The name of the Security list that you want to associate with the instance.
 	// Required
@@ -46,6 +46,9 @@ type CreateSecurityAssociationInput struct {
 
 // CreateSecurityAssociation creates a security association between the given VCable and security list.
 func (c *SecurityAssociationsClient) CreateSecurityAssociation(createInput *CreateSecurityAssociationInput) (*SecurityAssociationInfo, error) {
+	if createInput.Name != "" {
+		createInput.Name = c.getQualifiedName(createInput.Name)
+	}
 	createInput.VCable = c.getQualifiedName(createInput.VCable)
 	createInput.SecList = c.getQualifiedName(createInput.SecList)
 


### PR DESCRIPTION
The `name` field for a Security Association is optional (in that it'll be generated if it doesn't exist). However if specified it needs to be qualified

Tests pass:

```
$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccSecurityAssociationLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccSecurityAssociationLifeCycle -timeout 120m
=== RUN   TestAccSecurityAssociationLifeCycle
--- PASS: TestAccSecurityAssociationLifeCycle (238.16s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	238.168s
```