### PR TITLE
uncomplicate vnic sets resource

### DIFF
--- a/compute/routes_test.go
+++ b/compute/routes_test.go
@@ -55,9 +55,9 @@ func TestAccRoutesLifeCycle(t *testing.T) {
 	defer tearDownInstances(t, iClient, createdInstance.Name, createdInstance.ID)
 
 	vnicSetInput := &CreateVirtualNICSetInput{
-		Name:            _RouteTestName,
-		Description:     _RouteTestDescription,
-		VirtualNICNames: []string{createdInstance.Networking["eth0"].Vnic},
+		Name:        _RouteTestName,
+		Description: _RouteTestDescription,
+		VirtualNICs: []string{createdInstance.Networking["eth0"].Vnic},
 	}
 
 	createdSet, err := vClient.CreateVirtualNICSet(vnicSetInput)

--- a/compute/virtual_nic_sets_test.go
+++ b/compute/virtual_nic_sets_test.go
@@ -71,7 +71,7 @@ func TestAccVirtNICSetsLifeCycle(t *testing.T) {
 	}
 }
 
-func TestAccVirtNICSetAddNICS(t *testing.T) {
+func TestAccVirtNICSetsAddNICS(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
 	// Fist, create necessary clients
@@ -133,10 +133,10 @@ func TestAccVirtNICSetAddNICS(t *testing.T) {
 
 	// Create virtual nic set using two of the created vNICs
 	input := &CreateVirtualNICSetInput{
-		Name:            "test-acc-nic-set-nics",
-		Description:     "testing nic sets",
-		Tags:            []string{"test-tag"},
-		VirtualNICNames: []string{vNIC1, vNIC2},
+		Name:        "test-acc-nic-set-nics",
+		Description: "testing nic sets",
+		Tags:        []string{"test-tag"},
+		VirtualNICs: []string{vNIC1, vNIC2},
 	}
 
 	createdSet, err := vnClient.CreateVirtualNICSet(input)
@@ -166,10 +166,10 @@ func TestAccVirtNICSetAddNICS(t *testing.T) {
 
 	// Update the set with the third vNIC
 	updateInput := &UpdateVirtualNICSetInput{
-		Name:            createdSet.Name,
-		Description:     createdSet.Description,
-		Tags:            createdSet.Tags,
-		VirtualNICNames: []string{vNIC1, vNIC2, vNIC3},
+		Name:        createdSet.Name,
+		Description: createdSet.Description,
+		Tags:        createdSet.Tags,
+		VirtualNICs: []string{vNIC1, vNIC2, vNIC3},
 	}
 
 	updatedSet, err := vnClient.UpdateVirtualNICSet(updateInput)


### PR DESCRIPTION
Previously the vnic sets resource would populate an array of vNIC structs with information on each of the vNIC inside the list. However, in order to create a vNIC set a user will need to already have the name of each of the vNICs inside the set. Thus allowing them to use the vNIC data source if they need to reference data on a specific vNIC. That will also allow them to be more clear on the resource naming for each vNIC as well.

Tests Pass:
```
$ make testacc TEST=./compute TESTARGS='-run=TestAccVirtNICSetsLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccVirtNICSetsLifeCycle -timeout 120m
=== RUN   TestAccVirtNICSetsLifeCycle
--- PASS: TestAccVirtNICSetsLifeCycle (6.60s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        6.620s
```

```
$ make testacc TEST=./compute TESTARGS='-run=TestAccVirtNICSetsAddNICS'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccVirtNICSetsAddNICS -timeout 120m
=== RUN   TestAccVirtNICSetsAddNICS
--- PASS: TestAccVirtNICSetsAddNICS (126.21s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        126.237s
```