### PR TITLE
Deferring the deletion of the SSH Key

### DIFF
--- a/compute/ssh_keys_integration_test.go
+++ b/compute/ssh_keys_integration_test.go
@@ -1,0 +1,80 @@
+package compute
+
+import (
+	"log"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+func TestAccSSHKeyLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	name := "test-key"
+
+	sshKeyClient, err := getSSHKeysClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Obtained SSH Key Client\n")
+
+	createSSHKeyInput := CreateSSHKeyInput{
+		Name:    name,
+		Key:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7BzZyp8CWN7tfIZiZwWx8H9RO2ClKu0ru/+bGEsUmHmSS7aA+iPBVqeK1Kr2nVkoG/32GaMLfVNRlRgZZGTBTFM5nnytNoo3DC9dnIPuIu95TbF1afGkVFNNyeJkC5bQDDaRDMaYBbPVJTa6bA8v7nmzvElQHPRtdRqZnFx80QHdrgTluqhtrxWDBCYMSm2meL/NU11kijoKfYSReT4lroglSxnkvP0vjUqUSvZ6tI231Ggvxg4TU1TL4OgtNyfQgXK585V05n7IT9iiJHThah2/ZGsb0DZimj/D5LxngciXVOkOR1sDt8pQb7QCxgoxOO3sa1K3pFi5UAJQ10tSyhu0yn0AnRG13NWK6DlLKhLzZM5jhGJeeYYuwCL5fzJojflouHgebOO62gqNANkUcf7cWUBJRWjSAYuXe/C6rJOriZuUkC87QpffpYd2WaJmqnjAaj7NaqOTzk5ltpS39EjMenyXWWw1MPs7eEB/A/Rfol0cHzGqoXaIZAJVaEpW7ePWEj193CqSc6uh1nwAT15rvh63z2l1iPL0CbuF4GwZWsIZ6roirmwPpKY79kAls69EKsa7bydSQuYpbU5otkT20FIbtHmyFMYpJzYM6sQHoljO2AHWmWChkYtqglbFPrQgwIrsAHbJtmzNcmbXLUm1AY+SjZd1UYqPBjFDb7w== your_email@example.com",
+		Enabled: true,
+	}
+	sshKey, err := sshKeyClient.CreateSSHKey(&createSSHKeyInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully created SSH Key: %+v\n", sshKey)
+
+	defer tearDownSSHKey(t, sshKeyClient, name)
+
+	getSSHKeyInput := GetSSHKeyInput{
+		Name: name,
+	}
+	getSSHKeyOutput, err := sshKeyClient.GetSSHKey(&getSSHKeyInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sshKey.Key != getSSHKeyOutput.Key {
+		t.Fatalf("Created and retrived keys don't match %s %s\n", sshKey.Key, getSSHKeyOutput.Key)
+	}
+	log.Printf("Successfully retrieved ssh key\n")
+
+	updateSSHKeyInput := UpdateSSHKeyInput{
+		Name:    name,
+		Key:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7BzZyp8CWN7tfIZiZwWx8H9RO2ClKu0ru/+bGEsUmHmSS7aA+iPBVqeK1Kr2nVkoG/32GaMLfVNRlRgZZGTBTFM5nnytNoo3DC9dnIPuIu95TbF1afGkVFNNyeJkC5bQDDaRDMaYBbPVJTa6bA8v7nmzvElQHPRtdRqZnFx80QHdrgTluqhtrxWDBCYMSm2meL/NU11kijoKfYSReT4lroglSxnkvP0vjUqUSvZ6tI231Ggvxg4TU1TL4OgtNyfQgXK585V05n7IT9iiJHThah2/ZGsb0DZimj/D5LxngciXVOkOR1sDt8pQb7QCxgoxOO3sa1K3pFi5UAJQ10tSyhu0yn0AnRG13NWK6DlLKhLzZM5jhGJeeYYuwCL5fzJojflouHgebOO62gqNANkUcf7cWUBJRWjSAYuXe/C6rJOriZuUkC87QpffpYd2WaJmqnjAaj7NaqOTzk5ltpS39EjMenyXWWw1MPs7eEB/A/Rfol0cHzGqoXaIZAJVaEpW7ePWEj193CqSc6uh1nwAT15rvh63z2l1iPL0CbuF4GwZWsIZ6roirmwPpKY79kAls69EKsa7bydSQuYpbU5otkT20FIbtHmyFMYpJzYM6sQHoljO2AHWmWChkYtqglbFPrQgwIrsAHbJtmzNcmbXLUm1AY+SjZd1UYqPBjFDb7w== your_email@example.com",
+		Enabled: false,
+	}
+	updateSSHKeyOutput, err := sshKeyClient.UpdateSSHKey(&updateSSHKeyInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updateSSHKeyOutput.Enabled != updateSSHKeyInput.Enabled {
+		t.Fatalf("Key not successfully updated \nDesired: %s \nActual: %s", updateSSHKeyInput.Key, updateSSHKeyOutput.Key)
+	}
+	log.Printf("Successfully updated ssh key\n")
+}
+
+func getSSHKeysClient() (*SSHKeysClient, error) {
+	client, err := getTestClient(&opc.Config{})
+	if err != nil {
+		return &SSHKeysClient{}, err
+	}
+
+	return client.SSHKeys(), nil
+}
+
+func tearDownSSHKey(t *testing.T, client *SSHKeysClient, name string) {
+	deleteSSHKeyInput := DeleteSSHKeyInput{
+		Name: name,
+	}
+	err := client.DeleteSSHKey(&deleteSSHKeyInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully deleted SSH Key")
+}

--- a/compute/ssh_keys_test.go
+++ b/compute/ssh_keys_test.go
@@ -1,71 +1,13 @@
 package compute
 
 import (
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
-	"github.com/hashicorp/go-oracle-terraform/opc"
 )
-
-func TestAccSSHKeyLifeCycle(t *testing.T) {
-	helper.Test(t, helper.TestCase{})
-
-	sshKeyClient, err := getSSHKeysClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Printf("Obtained SSH Key Client\n")
-
-	createSSHKeyInput := CreateSSHKeyInput{
-		Name:    "test-key",
-		Key:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7BzZyp8CWN7tfIZiZwWx8H9RO2ClKu0ru/+bGEsUmHmSS7aA+iPBVqeK1Kr2nVkoG/32GaMLfVNRlRgZZGTBTFM5nnytNoo3DC9dnIPuIu95TbF1afGkVFNNyeJkC5bQDDaRDMaYBbPVJTa6bA8v7nmzvElQHPRtdRqZnFx80QHdrgTluqhtrxWDBCYMSm2meL/NU11kijoKfYSReT4lroglSxnkvP0vjUqUSvZ6tI231Ggvxg4TU1TL4OgtNyfQgXK585V05n7IT9iiJHThah2/ZGsb0DZimj/D5LxngciXVOkOR1sDt8pQb7QCxgoxOO3sa1K3pFi5UAJQ10tSyhu0yn0AnRG13NWK6DlLKhLzZM5jhGJeeYYuwCL5fzJojflouHgebOO62gqNANkUcf7cWUBJRWjSAYuXe/C6rJOriZuUkC87QpffpYd2WaJmqnjAaj7NaqOTzk5ltpS39EjMenyXWWw1MPs7eEB/A/Rfol0cHzGqoXaIZAJVaEpW7ePWEj193CqSc6uh1nwAT15rvh63z2l1iPL0CbuF4GwZWsIZ6roirmwPpKY79kAls69EKsa7bydSQuYpbU5otkT20FIbtHmyFMYpJzYM6sQHoljO2AHWmWChkYtqglbFPrQgwIrsAHbJtmzNcmbXLUm1AY+SjZd1UYqPBjFDb7w== your_email@example.com",
-		Enabled: true,
-	}
-	sshKey, err := sshKeyClient.CreateSSHKey(&createSSHKeyInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Printf("Successfully created SSH Key: %+v\n", sshKey)
-
-	getSSHKeyInput := GetSSHKeyInput{
-		Name: sshKey.Name,
-	}
-	getSSHKeyOutput, err := sshKeyClient.GetSSHKey(&getSSHKeyInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sshKey.Key != getSSHKeyOutput.Key {
-		t.Fatalf("Created and retrived keys don't match %s %s\n", sshKey.Key, getSSHKeyOutput.Key)
-	}
-	log.Printf("Successfully retrieved ssh key\n")
-
-	updateSSHKeyInput := UpdateSSHKeyInput{
-		Name:    sshKey.Name,
-		Key:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7BzZyp8CWN7tfIZiZwWx8H9RO2ClKu0ru/+bGEsUmHmSS7aA+iPBVqeK1Kr2nVkoG/32GaMLfVNRlRgZZGTBTFM5nnytNoo3DC9dnIPuIu95TbF1afGkVFNNyeJkC5bQDDaRDMaYBbPVJTa6bA8v7nmzvElQHPRtdRqZnFx80QHdrgTluqhtrxWDBCYMSm2meL/NU11kijoKfYSReT4lroglSxnkvP0vjUqUSvZ6tI231Ggvxg4TU1TL4OgtNyfQgXK585V05n7IT9iiJHThah2/ZGsb0DZimj/D5LxngciXVOkOR1sDt8pQb7QCxgoxOO3sa1K3pFi5UAJQ10tSyhu0yn0AnRG13NWK6DlLKhLzZM5jhGJeeYYuwCL5fzJojflouHgebOO62gqNANkUcf7cWUBJRWjSAYuXe/C6rJOriZuUkC87QpffpYd2WaJmqnjAaj7NaqOTzk5ltpS39EjMenyXWWw1MPs7eEB/A/Rfol0cHzGqoXaIZAJVaEpW7ePWEj193CqSc6uh1nwAT15rvh63z2l1iPL0CbuF4GwZWsIZ6roirmwPpKY79kAls69EKsa7bydSQuYpbU5otkT20FIbtHmyFMYpJzYM6sQHoljO2AHWmWChkYtqglbFPrQgwIrsAHbJtmzNcmbXLUm1AY+SjZd1UYqPBjFDb7w== your_email@example.com",
-		Enabled: false,
-	}
-	updateSSHKeyOutput, err := sshKeyClient.UpdateSSHKey(&updateSSHKeyInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if updateSSHKeyOutput.Enabled != updateSSHKeyInput.Enabled {
-		t.Fatalf("Key not successfully updated \nDesired: %s \nActual: %s", updateSSHKeyInput.Key, updateSSHKeyOutput.Key)
-	}
-	log.Printf("Successfully updated ssh key\n")
-
-	deleteSSHKeyInput := DeleteSSHKeyInput{
-		Name: sshKey.Name,
-	}
-	err = sshKeyClient.DeleteSSHKey(&deleteSSHKeyInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Printf("Successfully deleted SSH Key\n")
-}
 
 // Test that the client can create an instance.
 func TestAccSSHClient_CreateKey(t *testing.T) {
@@ -135,15 +77,6 @@ func getStubSSHKeysClient(server *httptest.Server) (*SSHKeysClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.SSHKeys(), nil
-}
-
-func getSSHKeysClient() (*SSHKeysClient, error) {
-	client, err := getTestClient(&opc.Config{})
-	if err != nil {
-		return &SSHKeysClient{}, err
-	}
-
 	return client.SSHKeys(), nil
 }
 


### PR DESCRIPTION
Noticed we weren't deferring the deletion of the SSH Key

Tests pass:

```
$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccSSH'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccSSH -timeout 120m
=== RUN   TestAccSSHKeyLifeCycle
--- PASS: TestAccSSHKeyLifeCycle (3.18s)
=== RUN   TestAccSSHClient_CreateKey
--- PASS: TestAccSSHClient_CreateKey (0.00s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	3.192s
```