### PR TITLE
Renaming the Name field

### DIFF
--- a/compute/image_list_entries.go
+++ b/compute/image_list_entries.go
@@ -11,7 +11,7 @@ type ImageListEntriesClient struct {
 }
 
 // ImageListEntries() returns an ImageListEntriesClient that can be used to access the
-// necessary CRUD functions for Image List Entrys.
+// necessary CRUD functions for Image List Entry's.
 func (c *Client) ImageListEntries() *ImageListEntriesClient {
 	return &ImageListEntriesClient{
 		ResourceClient: ResourceClient{
@@ -33,7 +33,7 @@ type ImageListEntryInfo struct {
 	// Oracle Compute Cloud Service (IaaS).
 	Attributes map[string]interface{} `json:"attributes"`
 	// Name of the imagelist.
-	ImageList string `json:"imagelist"`
+	Name string `json:"imagelist"`
 	// A list of machine images.
 	MachineImages []string `json:"machineimages"`
 	// Uniform Resource Identifier for the Image List Entry


### PR DESCRIPTION
Tests still pass:
```
$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccImageList'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccImageList -timeout 120m
=== RUN   TestAccImageListEntriesLifeCycle
--- PASS: TestAccImageListEntriesLifeCycle (4.64s)
=== RUN   TestAccImageListLifeCycle
--- PASS: TestAccImageListLifeCycle (3.16s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	7.811s
```