### PR TITLE
Image List Entries: Version from String -> Int

### DIFF
--- a/compute/image_list_entries.go
+++ b/compute/image_list_entries.go
@@ -1,5 +1,7 @@
 package compute
 
+import "fmt"
+
 const (
 	ImageListEntryDescription   = "image list entry"
 	ImageListEntryContainerPath = "/imagelist"
@@ -63,7 +65,7 @@ type CreateImageListEntryInput struct {
 // Create a new Image List Entry from an ImageListEntriesClient and an input struct.
 // Returns a populated Info struct for the Image List Entry, and any errors
 func (c *ImageListEntriesClient) CreateImageListEntry(input *CreateImageListEntryInput) (*ImageListEntryInfo, error) {
-	c.updateClientPaths(input.Name, "")
+	c.updateClientPaths(input.Name, -1)
 	var imageListEntryInfo ImageListEntryInfo
 	if err := c.createResource(&input, &imageListEntryInfo); err != nil {
 		return nil, err
@@ -75,7 +77,7 @@ type GetImageListEntryInput struct {
 	// The name of the Image List
 	Name string
 	// Version number of these machineImages in the imagelist.
-	Version string
+	Version int
 }
 
 // Returns a populated ImageListEntryInfo struct from an input struct
@@ -92,7 +94,7 @@ type DeleteImageListEntryInput struct {
 	// The name of the Image List
 	Name string
 	// Version number of these machineImages in the imagelist.
-	Version string
+	Version int
 }
 
 func (c *ImageListEntriesClient) DeleteImageListEntry(input *DeleteImageListEntryInput) error {
@@ -100,14 +102,14 @@ func (c *ImageListEntriesClient) DeleteImageListEntry(input *DeleteImageListEntr
 	return c.deleteResource("")
 }
 
-func (c *ImageListEntriesClient) updateClientPaths(name, version string) {
+func (c *ImageListEntriesClient) updateClientPaths(name string, version int) {
 	var containerPath, resourcePath string
 	name = c.getQualifiedName(name)
 	containerPath = ImageListEntryContainerPath + name + "/entry/"
 	resourcePath = ImageListEntryContainerPath + name + "/entry"
-	if version != "" {
-		containerPath = containerPath + version
-		resourcePath = resourcePath + "/" + version
+	if version != -1 {
+		containerPath = fmt.Sprintf("%s%d", containerPath, version)
+		resourcePath = fmt.Sprintf("%s/%d", resourcePath, version)
 	}
 	c.ContainerPath = containerPath
 	c.ResourceRootPath = resourcePath

--- a/compute/image_list_entries_test.go
+++ b/compute/image_list_entries_test.go
@@ -3,7 +3,6 @@ package compute
 import (
 	"log"
 	"reflect"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
@@ -12,7 +11,7 @@ import (
 
 const (
 	_ImageListEntryTestName    = "test-acc-ip-network-image-list-entry"
-	_ImageListEntryTestVersion = "1"
+	_ImageListEntryTestVersion = 1
 )
 
 func TestAccImageListEntriesLifeCycle(t *testing.T) {
@@ -41,7 +40,7 @@ func TestAccImageListEntriesLifeCycle(t *testing.T) {
 	createInput := &CreateImageListEntryInput{
 		Name:          _ImageListEntryTestName,
 		MachineImages: []string{"/oracle/public/oel_6.7_apaas_16.4.5_1610211300"},
-		Version:       1,
+		Version:       _ImageListEntryTestVersion,
 	}
 
 	createdImageListEntry, err := entryClient.CreateImageListEntry(createInput)
@@ -68,7 +67,7 @@ func TestAccImageListEntriesLifeCycle(t *testing.T) {
 func destroyImageListEntry(t *testing.T, svc *ImageListEntriesClient, imageListEntry *ImageListEntryInfo) {
 	deleteInput := &DeleteImageListEntryInput{
 		Name:    imageListEntry.Uri,
-		Version: strconv.Itoa(imageListEntry.Version),
+		Version: imageListEntry.Version,
 	}
 	if err := svc.DeleteImageListEntry(deleteInput); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Tests:
```
$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccImageList'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccImageList -timeout 120m
=== RUN   TestAccImageListEntriesLifeCycle
--- PASS: TestAccImageListEntriesLifeCycle (6.27s)
=== RUN   TestAccImageListLifeCycle
--- PASS: TestAccImageListLifeCycle (5.74s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	12.029s
```