### PR TITLE
Updates for acceptance tests

### DIFF
--- a/compute/ip_networks.go
+++ b/compute/ip_networks.go
@@ -141,7 +141,7 @@ type UpdateIPNetworkInput struct {
 	//that have non-overlapping addresses, so that instances on these networks can exchange packets
 	//with each other without NAT.
 	// Optional
-	IPNetworkExchange string `json:"ipNetworkExchange"`
+	IPNetworkExchange string `json:"ipNetworkExchange,omitempty"`
 
 	// Description of the IPNetwork
 	// Optional

--- a/compute/virtual_nic_sets_test.go
+++ b/compute/virtual_nic_sets_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"sort"
+
 	"github.com/hashicorp/go-oracle-terraform/helper"
 	"github.com/hashicorp/go-oracle-terraform/opc"
 )
@@ -37,6 +39,7 @@ func TestAccVirtNICSetsLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	// Verify they're the same
 	if createdSet.Name != returnedSet.Name {
 		t.Fatalf("Mismatched Sets found.\nExpected: %+v\nReceived: %+v", createdSet, returnedSet)
@@ -65,6 +68,11 @@ func TestAccVirtNICSetsLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Need to sort slices, for ordering. The Provider takes care of this at the end-user level, but for
+	// testing these can be out of whack when returned from the API
+	sort.Strings(updatedSet.Tags)
+	sort.Strings(returnedSet.Tags)
 
 	if !reflect.DeepEqual(updatedSet, returnedSet) {
 		t.Fatalf("Mismatched Sets found.\nExpected: %+v\nReceived: %+v", updatedSet, returnedSet)
@@ -159,6 +167,10 @@ func TestAccVirtNICSetsAddNICS(t *testing.T) {
 		t.Fatalf("Expected 2 sets of virtual nics, got: %d", len(returnedSet.VirtualNICs))
 	}
 
+	// Sort slices
+	sort.Strings(createdSet.VirtualNICs)
+	sort.Strings(returnedSet.VirtualNICs)
+
 	// Verify that the vNICs in the returned set are populated
 	if !reflect.DeepEqual(createdSet, returnedSet) {
 		t.Fatalf("Mismatch Found!\nExpected: %+v\nReceived: %+v", createdSet, returnedSet)
@@ -182,6 +194,10 @@ func TestAccVirtNICSetsAddNICS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Sort slices
+	sort.Strings(updatedSet.VirtualNICs)
+	sort.Strings(returnedSet.VirtualNICs)
 
 	// Verify that the vNICs in the returned set are populated
 	if !reflect.DeepEqual(updatedSet, returnedSet) {


### PR DESCRIPTION
```
$ make testacc
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v $(go list ./... |grep -v 'vendor')  -timeout 120m
=== RUN   TestAccACLLifeCycle
--- PASS: TestAccACLLifeCycle (4.24s)
=== RUN   TestAccACLsClient_CreateRule
--- PASS: TestAccACLsClient_CreateRule (0.00s)
=== RUN   TestAccObtainAuthenticationCookie
--- PASS: TestAccObtainAuthenticationCookie (0.00s)
=== RUN   TestAccAuthenticationCookieSentInRequestsFromAuthenticatedClient
--- PASS: TestAccAuthenticationCookieSentInRequestsFromAuthenticatedClient (0.00s)
=== RUN   TestClient_qualifyList
--- PASS: TestClient_qualifyList (0.00s)
=== RUN   TestAccImageListEntriesLifeCycle
--- PASS: TestAccImageListEntriesLifeCycle (5.54s)
=== RUN   TestAccImageListLifeCycle
--- PASS: TestAccImageListLifeCycle (2.62s)
=== RUN   TestAccInstanceLifeCycle
--- PASS: TestAccInstanceLifeCycle (234.58s)
=== RUN   TestInstanceClient_CreateInstance
--- PASS: TestInstanceClient_CreateInstance (1.00s)
=== RUN   TestInstanceClient_RetrieveInstance
--- PASS: TestInstanceClient_RetrieveInstance (0.00s)
=== RUN   TestAccIPAddressPrefixSetsLifeCycle
--- PASS: TestAccIPAddressPrefixSetsLifeCycle (4.38s)
=== RUN   TestAccIPAddressReservationLifeCycle
--- PASS: TestAccIPAddressReservationLifeCycle (3.45s)
=== RUN   TestAccIPAssociationLifeCycle
--- PASS: TestAccIPAssociationLifeCycle (543.19s)
=== RUN   TestAccIPNetworkExchangesLifeCycle
--- PASS: TestAccIPNetworkExchangesLifeCycle (2.93s)
=== RUN   TestAccIPNetworksLifeCycle
--- PASS: TestAccIPNetworksLifeCycle (5.41s)
=== RUN   TestAccIPNetworksWithExchangesLifeCycle
--- PASS: TestAccIPNetworksWithExchangesLifeCycle (5.24s)
=== RUN   TestAccIPReservationLifeCycle
--- PASS: TestAccIPReservationLifeCycle (4.57s)
=== RUN   TestAccRoutesLifeCycle
--- PASS: TestAccRoutesLifeCycle (114.23s)
=== RUN   TestRoutesClient_CreateRoute
--- PASS: TestRoutesClient_CreateRoute (0.00s)
=== RUN   TestAccSecRuleLifeCycle
--- PASS: TestAccSecRuleLifeCycle (15.79s)
=== RUN   TestAccSecRulesClient_CreateRule
--- PASS: TestAccSecRulesClient_CreateRule (0.00s)
=== RUN   TestAccSecurityApplicationsTCPLifeCycle
--- PASS: TestAccSecurityApplicationsTCPLifeCycle (2.79s)
=== RUN   TestAccSecurityApplicationsICMPLifeCycle
--- PASS: TestAccSecurityApplicationsICMPLifeCycle (2.47s)
=== RUN   TestAccSecurityAssociationLifeCycle
--- PASS: TestAccSecurityAssociationLifeCycle (233.71s)
=== RUN   TestAccSecurityIPListLifeCycle
--- PASS: TestAccSecurityIPListLifeCycle (3.09s)
=== RUN   TestAccSecurityIPListsClient_CreateKey
--- PASS: TestAccSecurityIPListsClient_CreateKey (0.00s)
=== RUN   TestAccSecurityListLifeCycle
--- PASS: TestAccSecurityListLifeCycle (4.24s)
=== RUN   TestAccSecurityListsClient_CreateKey
--- PASS: TestAccSecurityListsClient_CreateKey (0.00s)
=== RUN   TestAccSecurityProtocolsLifeCycle
--- PASS: TestAccSecurityProtocolsLifeCycle (6.17s)
=== RUN   TestAccSecurityRulesLifeCycle
--- PASS: TestAccSecurityRulesLifeCycle (5.96s)
=== RUN   TestAccSecurityRulesWithOptionsLifeCycle
--- PASS: TestAccSecurityRulesWithOptionsLifeCycle (8.71s)
=== RUN   TestAccSSHKeyLifeCycle
--- PASS: TestAccSSHKeyLifeCycle (6.56s)
=== RUN   TestAccSSHClient_CreateKey
--- PASS: TestAccSSHClient_CreateKey (0.00s)
=== RUN   TestAccStorageAttachmentsLifecycle
--- PASS: TestAccStorageAttachmentsLifecycle (258.22s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageDetachmentSuccessful
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageDetachmentSuccessful (4.01s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageDetachmentTimeout
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageDetachmentTimeout (3.00s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedSuccessful
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedSuccessful (4.00s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedTimeout
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedTimeout (3.00s)
=== RUN   TestAccStorageVolumeLifecycle
--- PASS: TestAccStorageVolumeLifecycle (13.82s)
=== RUN   TestAccStorageVolumeBootableLifecycle
--- PASS: TestAccStorageVolumeBootableLifecycle (20.73s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful (4.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout (3.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful (4.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout (3.00s)
=== RUN   TestAccVirtNICSetsLifeCycle
--- PASS: TestAccVirtNICSetsLifeCycle (5.88s)
=== RUN   TestAccVirtNICSetsAddNICS
--- PASS: TestAccVirtNICSetsAddNICS (123.71s)
=== RUN   TestAccVirtNICLifeCycle
--- PASS: TestAccVirtNICLifeCycle (71.64s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        1742.935s
?       github.com/hashicorp/go-oracle-terraform/helper [no test files]
?       github.com/hashicorp/go-oracle-terraform/opc    [no test files]
```