### PR TITLE
Added ip address associations

### DIFF
--- a/compute/ip_address_associations.go
+++ b/compute/ip_address_associations.go
@@ -1,0 +1,152 @@
+package compute
+
+const (
+	IPAddressAssociationDescription   = "ip address association"
+	IPAddressAssociationContainerPath = "/network/v1/ipassociation/"
+	IPAddressAssociationResourcePath  = "/network/v1/ipassociation"
+)
+
+type IPAddressAssociationsClient struct {
+	ResourceClient
+}
+
+// IPAddressAssociations() returns an IPAddressAssociationsClient that can be used to access the
+// necessary CRUD functions for IP Address Associations.
+func (c *Client) IPAddressAssociations() *IPAddressAssociationsClient {
+	return &IPAddressAssociationsClient{
+		ResourceClient: ResourceClient{
+			Client:              c,
+			ResourceDescription: IPAddressAssociationDescription,
+			ContainerPath:       IPAddressAssociationContainerPath,
+			ResourceRootPath:    IPAddressAssociationResourcePath,
+		},
+	}
+}
+
+// IPAddressAssociationInfo contains the exported fields necessary to hold all the information about an
+// IP Address Association
+type IPAddressAssociationInfo struct {
+	// The name of the NAT IP address reservation.
+	IPAddressReservation string `json:"ipAddressReservation"`
+	// Name of the virtual NIC associated with this NAT IP reservation.
+	VNIC string `json:"vnic"`
+	// The name of the IP Address Association
+	Name string `json:"name"`
+	// Description of the IP Address Association
+	Description string `json:"description"`
+	// Slice of tags associated with the IP Address Association
+	Tags []string `json:"tags"`
+	// Uniform Resource Identifier for the IP Address Association
+	Uri string `json:"uri"`
+}
+
+type CreateIPAddressAssociationInput struct {
+	// The name of the IP Address Association to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// The name of the NAT IP address reservation.
+	// Optional
+	IPAddressReservation string `json:"ipAddressReservation,omitempty"`
+
+	// Name of the virtual NIC associated with this NAT IP reservation.
+	// Optional
+	VNIC string `json:"vnic,omitempty"`
+
+	// Description of the IPAddressAssociation
+	// Optional
+	Description string `json:"description"`
+
+	// String slice of tags to apply to the IP Address Association object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// Create a new IP Address Association from an IPAddressAssociationsClient and an input struct.
+// Returns a populated Info struct for the IP Address Association, and any errors
+func (c *IPAddressAssociationsClient) CreateIPAddressAssociation(input *CreateIPAddressAssociationInput) (*IPAddressAssociationInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+	input.IPAddressReservation = c.getQualifiedName(input.IPAddressReservation)
+	input.VNIC = c.getQualifiedName(input.VNIC)
+
+	var ipInfo IPAddressAssociationInfo
+	if err := c.createResource(&input, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type GetIPAddressAssociationInput struct {
+	// The name of the IP Address Association to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+// Returns a populated IPAddressAssociationInfo struct from an input struct
+func (c *IPAddressAssociationsClient) GetIPAddressAssociation(input *GetIPAddressAssociationInput) (*IPAddressAssociationInfo, error) {
+	input.Name = c.getQualifiedName(input.Name)
+
+	var ipInfo IPAddressAssociationInfo
+	if err := c.getResource(input.Name, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+// UpdateIPAddressAssociationInput defines what to update in a ip address association
+type UpdateIPAddressAssociationInput struct {
+	// The name of the IP Address Association to create. Object names can only contain alphanumeric,
+	// underscore, dash, and period characters. Names are case-sensitive.
+	// Required
+	Name string `json:"name"`
+
+	// The name of the NAT IP address reservation.
+	// Optional
+	IPAddressReservation string `json:"ipAddressReservation,omitempty"`
+
+	// Name of the virtual NIC associated with this NAT IP reservation.
+	// Optional
+	VNIC string `json:"vnic,omitempty"`
+
+	// Description of the IPAddressAssociation
+	// Optional
+	Description string `json:"description"`
+
+	// String slice of tags to apply to the IP Address Association object
+	// Optional
+	Tags []string `json:"tags"`
+}
+
+// UpdateIPAddressAssociation update the ip address association
+func (c *IPAddressAssociationsClient) UpdateIPAddressAssociation(updateInput *UpdateIPAddressAssociationInput) (*IPAddressAssociationInfo, error) {
+	updateInput.Name = c.getQualifiedName(updateInput.Name)
+	updateInput.IPAddressReservation = c.getQualifiedName(updateInput.IPAddressReservation)
+	updateInput.VNIC = c.getQualifiedName(updateInput.VNIC)
+	var ipInfo IPAddressAssociationInfo
+	if err := c.updateResource(updateInput.Name, updateInput, &ipInfo); err != nil {
+		return nil, err
+	}
+
+	return c.success(&ipInfo)
+}
+
+type DeleteIPAddressAssociationInput struct {
+	// The name of the IP Address Association to query for. Case-sensitive
+	// Required
+	Name string `json:"name"`
+}
+
+func (c *IPAddressAssociationsClient) DeleteIPAddressAssociation(input *DeleteIPAddressAssociationInput) error {
+	return c.deleteResource(input.Name)
+}
+
+// Unqualifies any qualified fields in the IPAddressAssociationInfo struct
+func (c *IPAddressAssociationsClient) success(info *IPAddressAssociationInfo) (*IPAddressAssociationInfo, error) {
+	c.unqualify(&info.Name)
+	c.unqualify(&info.VNIC)
+	c.unqualify(&info.IPAddressReservation)
+	return info, nil
+}

--- a/compute/ip_address_associations.go
+++ b/compute/ip_address_associations.go
@@ -29,7 +29,7 @@ type IPAddressAssociationInfo struct {
 	// The name of the NAT IP address reservation.
 	IPAddressReservation string `json:"ipAddressReservation"`
 	// Name of the virtual NIC associated with this NAT IP reservation.
-	VNIC string `json:"vnic"`
+	Vnic string `json:"vnic"`
 	// The name of the IP Address Association
 	Name string `json:"name"`
 	// Description of the IP Address Association
@@ -52,7 +52,7 @@ type CreateIPAddressAssociationInput struct {
 
 	// Name of the virtual NIC associated with this NAT IP reservation.
 	// Optional
-	VNIC string `json:"vnic,omitempty"`
+	Vnic string `json:"vnic,omitempty"`
 
 	// Description of the IPAddressAssociation
 	// Optional
@@ -68,7 +68,7 @@ type CreateIPAddressAssociationInput struct {
 func (c *IPAddressAssociationsClient) CreateIPAddressAssociation(input *CreateIPAddressAssociationInput) (*IPAddressAssociationInfo, error) {
 	input.Name = c.getQualifiedName(input.Name)
 	input.IPAddressReservation = c.getQualifiedName(input.IPAddressReservation)
-	input.VNIC = c.getQualifiedName(input.VNIC)
+	input.Vnic = c.getQualifiedName(input.Vnic)
 
 	var ipInfo IPAddressAssociationInfo
 	if err := c.createResource(&input, &ipInfo); err != nil {
@@ -109,7 +109,7 @@ type UpdateIPAddressAssociationInput struct {
 
 	// Name of the virtual NIC associated with this NAT IP reservation.
 	// Optional
-	VNIC string `json:"vnic,omitempty"`
+	Vnic string `json:"vnic,omitempty"`
 
 	// Description of the IPAddressAssociation
 	// Optional
@@ -124,7 +124,7 @@ type UpdateIPAddressAssociationInput struct {
 func (c *IPAddressAssociationsClient) UpdateIPAddressAssociation(updateInput *UpdateIPAddressAssociationInput) (*IPAddressAssociationInfo, error) {
 	updateInput.Name = c.getQualifiedName(updateInput.Name)
 	updateInput.IPAddressReservation = c.getQualifiedName(updateInput.IPAddressReservation)
-	updateInput.VNIC = c.getQualifiedName(updateInput.VNIC)
+	updateInput.Vnic = c.getQualifiedName(updateInput.Vnic)
 	var ipInfo IPAddressAssociationInfo
 	if err := c.updateResource(updateInput.Name, updateInput, &ipInfo); err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (c *IPAddressAssociationsClient) DeleteIPAddressAssociation(input *DeleteIP
 // Unqualifies any qualified fields in the IPAddressAssociationInfo struct
 func (c *IPAddressAssociationsClient) success(info *IPAddressAssociationInfo) (*IPAddressAssociationInfo, error) {
 	c.unqualify(&info.Name)
-	c.unqualify(&info.VNIC)
+	c.unqualify(&info.Vnic)
 	c.unqualify(&info.IPAddressReservation)
 	return info, nil
 }

--- a/compute/ip_address_associations_test.go
+++ b/compute/ip_address_associations_test.go
@@ -1,0 +1,163 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_IPAddressAssociationTestName        = "test-acc-ip-address-association"
+	_IPAddressAssociationTestDescription = "testing ip address association"
+)
+
+func TestAccIPAddressAssociationsLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	iClient, nClient, vnClient, err := getVirtNICsTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipNetwork, err := createTestIPNetwork(nClient, _IPNetworkTestPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyIPNetwork(t, nClient, ipNetwork.Name)
+
+	// In order to get details on a Virtual NIC we need to create the following resources
+	// - IP Network
+	// - Instance
+
+	instanceInput := &CreateInstanceInput{
+		Name:      _VirtNicInstanceTestName,
+		Label:     _VirtNicInstanceTestLabel,
+		Shape:     _VirtNicInstanceTestShape,
+		ImageList: _VirtNicInstanceTestImage,
+		Networking: map[string]NetworkingInfo{
+			"eth0": {
+				IPNetwork: ipNetwork.Name,
+				Vnic:      "eth0",
+			},
+		},
+	}
+
+	createdInstance, err := iClient.CreateInstance(instanceInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tearDownInstances(t, iClient, createdInstance.Name, createdInstance.ID)
+
+	// Use the static "eth0" interface, as we statically created that above
+	createdVNIC := createdInstance.Networking["eth0"].Vnic
+	getVNICInput := &GetVirtualNICInput{
+		Name: createdVNIC,
+	}
+
+	vNIC, err := vnClient.GetVirtualNIC(getVNICInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipaClient, err := getIPAddressReservationsTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resName := fmt.Sprintf("%s-%d", _TestIPAddressResName, helper.RInt())
+
+	input := &CreateIPAddressReservationInput{
+		Description:   _TestIPAddressResDesc,
+		IPAddressPool: PrivateIPAddressPool,
+		Name:          resName,
+		Tags:          []string{_TestIPAddressResTag},
+	}
+
+	ipRes, err := ipaClient.CreateIPAddressReservation(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyIPAddressReservation(t, ipaClient, resName)
+
+	svc, err := getIPAddressAssociationsClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createInput := &CreateIPAddressAssociationInput{
+		Name:                 _IPAddressAssociationTestName,
+		Description:          _IPAddressAssociationTestDescription,
+		IPAddressReservation: ipRes.Name,
+		VNIC:                 vNIC.Name,
+		Tags:                 []string{"testing"},
+	}
+
+	createdIPAddressAssociation, err := svc.CreateIPAddressAssociation(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Association succcessfully created")
+	defer destroyIPAddressAssociation(t, svc, _IPAddressAssociationTestName)
+
+	getInput := &GetIPAddressAssociationInput{
+		Name: _IPAddressAssociationTestName,
+	}
+	receivedIPAddressAssociation, err := svc.GetIPAddressAssociation(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Association successfully fetched")
+
+	if !reflect.DeepEqual(createdIPAddressAssociation, receivedIPAddressAssociation) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", createdIPAddressAssociation, receivedIPAddressAssociation)
+	}
+	if receivedIPAddressAssociation.VNIC != vNIC.Name {
+		t.Fatalf("VNIC Mismatch found after create.\nExpected: %+v\nReceived: %+v", vNIC.Name, receivedIPAddressAssociation.VNIC)
+	}
+	if receivedIPAddressAssociation.IPAddressReservation != ipRes.Name {
+		t.Fatalf("IPAddressReservation Mismatch found after create.\nExpected: %+v\nReceived: %+v", ipRes.Name, receivedIPAddressAssociation.IPAddressReservation)
+	}
+
+	updateInput := &UpdateIPAddressAssociationInput{
+		Name:                 _IPAddressAssociationTestName,
+		Description:          _IPAddressAssociationTestDescription,
+		IPAddressReservation: ipRes.Name,
+		VNIC:                 vNIC.Name,
+		Tags:                 []string{"testing-updated"},
+	}
+	updatedIPAddressAssociation, err := svc.UpdateIPAddressAssociation(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Print("IP Address Association succcessfully updated")
+	receivedIPAddressAssociation, err = svc.GetIPAddressAssociation(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(updatedIPAddressAssociation, receivedIPAddressAssociation) {
+		t.Fatalf("Mismatch found after create.\nExpected: %+v\nReceived: %+v", updatedIPAddressAssociation, receivedIPAddressAssociation)
+	}
+}
+
+func destroyIPAddressAssociation(t *testing.T, svc *IPAddressAssociationsClient, name string) {
+	input := &DeleteIPAddressAssociationInput{
+		Name: name,
+	}
+	if err := svc.DeleteIPAddressAssociation(input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getIPAddressAssociationsClient() (*IPAddressAssociationsClient, error) {
+	client, err := getTestClient(&opc.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.IPAddressAssociations(), nil
+}


### PR DESCRIPTION
Adding ip address associations and test. 

```
make testacc TEST=./compute/ TESTARGS='-run=TestAccIPAddressAssociationsLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccIPAddressAssociationsLifeCycle -timeout 120m
=== RUN   TestAccIPAddressAssociationsLifeCycle
--- PASS: TestAccIPAddressAssociationsLifeCycle (122.56s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	122.578s
```
