### PR TITLE
Storage Volumes: unqualifying the Image List

### DIFF
--- a/compute/storage_volumes.go
+++ b/compute/storage_volumes.go
@@ -187,6 +187,7 @@ type GetStorageVolumeInput struct {
 }
 
 func (c *StorageVolumeClient) success(result *StorageVolumeInfo) (*StorageVolumeInfo, error) {
+	c.unqualify(&result.ImageList)
 	c.unqualify(&result.Name)
 	c.unqualify(&result.Snapshot)
 


### PR DESCRIPTION
When creating a Storage Volume, the user provides the Name of the Image List - but the ID is returned

```
image_list:       "/Compute-hashicorp/burzin@hashicorp.com/test-acc-stor-vol-bootable-image-list-3807614912818737137" => "test-acc-stor-vol-bootable-image-list-3807614912818737137" (forces new resource)
```

Tests pass:

```
$ envchain oracle make testacc TEST=./compute/ TESTARGS='-run=TestAccStorageVolume'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccStorageVolume -timeout 120m
=== RUN   TestAccStorageVolumeSnapshot_Lifecycle
--- PASS: TestAccStorageVolumeSnapshot_Lifecycle (16.74s)
=== RUN   TestAccStorageVolumeLifecycle
--- PASS: TestAccStorageVolumeLifecycle (15.05s)
=== RUN   TestAccStorageVolumeBootableLifecycle
--- PASS: TestAccStorageVolumeBootableLifecycle (22.84s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful (4.01s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout (3.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful (4.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout (3.00s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	68.667s
```