### PR TITLE
Fixes ssh key create error

### DIFF
--- a/compute/ssh_keys.go
+++ b/compute/ssh_keys.go
@@ -47,16 +47,18 @@ type CreateSSHKeyInput struct {
 // CreateSSHKey creates a new SSH key with the given name, key and enabled flag.
 func (c *SSHKeysClient) CreateSSHKey(createInput *CreateSSHKeyInput) (*SSHKey, error) {
 	var keyInfo SSHKey
-	createInput.Name = c.getQualifiedName(createInput.Name)
-	if err := c.createResource(&createInput, &keyInfo); err != nil {
-		return nil, err
-	}
-
+	// We have to update after create to get the full ssh key into opc
 	updateSSHKeyInput := UpdateSSHKeyInput{
 		Name:    createInput.Name,
 		Key:     createInput.Key,
 		Enabled: createInput.Enabled,
 	}
+
+	createInput.Name = c.getQualifiedName(createInput.Name)
+	if err := c.createResource(&createInput, &keyInfo); err != nil {
+		return nil, err
+	}
+
 	_, err := c.UpdateSSHKey(&updateSSHKeyInput)
 	if err != nil {
 		return nil, err

--- a/compute/ssh_keys.go
+++ b/compute/ssh_keys.go
@@ -52,6 +52,16 @@ func (c *SSHKeysClient) CreateSSHKey(createInput *CreateSSHKeyInput) (*SSHKey, e
 		return nil, err
 	}
 
+	updateSSHKeyInput := UpdateSSHKeyInput{
+		Name:    createInput.Name,
+		Key:     createInput.Key,
+		Enabled: createInput.Enabled,
+	}
+	_, err := c.UpdateSSHKey(&updateSSHKeyInput)
+	if err != nil {
+		return nil, err
+	}
+
 	return c.success(&keyInfo)
 }
 

--- a/compute/ssh_keys_integration_test.go
+++ b/compute/ssh_keys_integration_test.go
@@ -39,8 +39,8 @@ func TestAccSSHKeyLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sshKey.Key != getSSHKeyOutput.Key {
-		t.Fatalf("Created and retrived keys don't match %s %s\n", sshKey.Key, getSSHKeyOutput.Key)
+	if createSSHKeyInput.Key != getSSHKeyOutput.Key {
+		t.Fatalf("Created and retrived keys don't match %s\n%s\n", createSSHKeyInput.Key, getSSHKeyOutput.Key)
 	}
 	log.Printf("Successfully retrieved ssh key\n")
 


### PR DESCRIPTION
The Create API call for ssh keys doesn't accept any trailing comments in ssh keys. For example 
```ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7BzZyp8CWN7tfIZiZwWx8H9RO2ClKu0ru...== your_email@example.com```, ```your_email@example.com``` will be lost in the call to create. This is problem in Terraform where Terraform will want to update the ssh key to add the trailing comment. To fix this, we just have immediately run update after we create the ssh key. 
This PR also updates the test to check the original key instead of the key we get back from the create call

```
make testacc TEST=./compute/ TESTARGS='-run=TestAccSSHKeyLifeCycle'
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute/ -run=TestAccSSHKeyLifeCycle -timeout 120m
=== RUN   TestAccSSHKeyLifeCycle
--- PASS: TestAccSSHKeyLifeCycle (3.95s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	3.972s
```