### PR TITLE
opc: Add max_retries capabilities

### DIFF
--- a/compute/client_test.go
+++ b/compute/client_test.go
@@ -2,11 +2,9 @@ package compute
 
 import (
 	"fmt"
-	"testing"
-
 	"net/http"
-
 	"net/url"
+	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/opc"
 	"github.com/kylelemons/godebug/pretty"

--- a/compute/client_test.go
+++ b/compute/client_test.go
@@ -4,7 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"net/http"
+
+	"net/url"
+
+	"github.com/hashicorp/go-oracle-terraform/opc"
 	"github.com/kylelemons/godebug/pretty"
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestClient_qualifyList(t *testing.T) {
@@ -32,5 +38,43 @@ func TestClient_qualifyList(t *testing.T) {
 
 	if diff := pretty.Compare(result, expected); diff != "" {
 		t.Fatalf("Qualified List Diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestClient_retryHTTP(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	endpoint, err := url.Parse("http://foo.bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := Client{}
+	client.maxRetries = opc.Int(5)
+	// Can't use a custom transport, otherwise httpmock won't catch request
+	client.httpClient = http.DefaultClient
+	client.apiEndpoint = endpoint
+	client.logger = opc.NewDefaultLogger()
+	client.loglevel = opc.LogLevel()
+
+	httpmock.RegisterResponder("GET", "http://foo.bar/",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(404, "mocked error message"), nil
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://foo.bar/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, reqErr := client.retryRequest(req)
+	if reqErr == nil {
+		t.Fatalf("Expected error, got none")
+	}
+
+	if httpmock.GetTotalCallCount() != 5 {
+		t.Fatalf("Expected 5 retries, got: %d", httpmock.GetTotalCallCount())
 	}
 }

--- a/compute/test_utils.go
+++ b/compute/test_utils.go
@@ -3,15 +3,13 @@ package compute
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
-
 	"time"
-
-	"log"
 
 	"github.com/hashicorp/go-oracle-terraform/opc"
 )

--- a/opc/convert.go
+++ b/opc/convert.go
@@ -3,3 +3,7 @@ package opc
 func String(v string) *string {
 	return &v
 }
+
+func Int(v int) *int {
+	return &v
+}

--- a/scripts/errcheck.sh
+++ b/scripts/errcheck.sh
@@ -11,7 +11,7 @@ fi
 err_files=$(errcheck -ignoretests \
   -ignore 'bytes:.*' \
   -ignore 'io:Close|Write' \
-  ./...)
+  $(go list ./... | grep -v /vendor/))
 
 if [[ -n ${err_files} ]]; then
     echo 'Unchecked errors found in the following places:'

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/LICENSE
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Jared Morse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/README.md
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/README.md
@@ -1,0 +1,116 @@
+# httpmock [![Build Status](https://travis-ci.org/jarcoal/httpmock.png?branch=master)](https://travis-ci.org/jarcoal/httpmock)
+
+Easy mocking of http responses from external resources.
+
+## Install
+
+Uses gopkg to read from `v1` branch:
+
+    go get gopkg.in/jarcoal/httpmock.v1
+
+You can also use vendoring for the v1 branch if you feel so inclined.
+
+Currently supports Go 1.7 but also works with 1.6 for now. 
+
+### Simple Example:
+```go
+func TestFetchArticles(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
+		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+
+  // get count info
+  httpmock.GetTotalCallCount()
+
+  // get the amount of calls for the registered responder
+  info := httpmock.GetCallCountInfo()
+  info["GET https://api.mybiz.com/articles.json"] // number of GET calls made to https://api.mybiz.com/articles.json
+
+	// do stuff that makes a request to articles.json
+}
+```
+
+### Advanced Example:
+```go
+func TestFetchArticles(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// our database of articles
+	articles := make([]map[string]interface{}, 0)
+
+	// mock to list out the articles
+	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
+		func(req *http.Request) (*http.Response, error) {
+			resp, err := httpmock.NewJsonResponse(200, articles)
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return resp, nil
+		},
+	)
+
+	// mock to add a new article
+	httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles.json",
+		func(req *http.Request) (*http.Response, error) {
+			article := make(map[string]interface{})
+			if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
+				return httpmock.NewStringResponse(400, ""), nil
+			}
+
+			articles = append(articles, article)
+
+			resp, err := httpmock.NewJsonResponse(200, article)
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return resp, nil
+		},
+	)
+
+	// do stuff that adds and checks articles
+}
+```
+
+### [Ginkgo](https://onsi.github.io/ginkgo/) Example:
+```go
+// article_suite_test.go
+
+import (
+	// ...
+	"github.com/jarcoal/httpmock"
+)
+// ...
+var _ = BeforeSuite(func() {
+	// block all HTTP requests
+	httpmock.Activate()
+})
+
+var _ = BeforeEach(func() {
+	// remove any mocks
+	httpmock.Reset()
+})
+
+var _ = AfterSuite(func() {
+	httpmock.DeactivateAndReset()
+})
+
+
+// article_test.go
+
+import (
+	// ...
+	"github.com/jarcoal/httpmock"
+)
+
+var _ = Describe("Articles", func() {
+	It("returns a list of articles", func() {
+		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
+			httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+
+		// do stuff that makes a request to articles.json
+	})
+})
+```

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/doc.go
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/doc.go
@@ -1,0 +1,56 @@
+/*
+HTTPmock provides tools for mocking HTTP responses.
+
+Simple Example:
+	func TestFetchArticles(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
+			httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+
+		// do stuff that makes a request to articles.json
+	}
+
+Advanced Example:
+	func TestFetchArticles(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// our database of articles
+		articles := make([]map[string]interface{}, 0)
+
+		// mock to list out the articles
+		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(200, articles)
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				return resp
+			},
+		)
+
+		// mock to add a new article
+		httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles.json",
+			func(req *http.Request) (*http.Response, error) {
+				article := make(map[string]interface{})
+				if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
+					return httpmock.NewStringResponse(400, ""), nil
+				}
+
+				articles = append(articles, article)
+
+				resp, err := httpmock.NewJsonResponse(200, article)
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		// do stuff that adds and checks articles
+	}
+
+*/
+package httpmock

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/env.go
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/env.go
@@ -1,0 +1,11 @@
+package httpmock
+
+import (
+	"os"
+)
+
+var envVarName = "GONOMOCKS"
+
+func Disabled() bool {
+	return os.Getenv(envVarName) != ""
+}

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/response.go
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/response.go
@@ -1,0 +1,134 @@
+package httpmock
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ResponderFromResponse wraps an *http.Response in a Responder
+func ResponderFromResponse(resp *http.Response) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		res := new(http.Response)
+		*res = *resp
+		res.Request = req
+		return res, nil
+	}
+}
+
+// NewErrorResponder creates a Responder that returns an empty request and the
+// given error. This can be used to e.g. imitate more deep http errors for the
+// client.
+func NewErrorResponder(err error) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return nil, err
+	}
+}
+
+// NewStringResponse creates an *http.Response with a body based on the given string.  Also accepts
+// an http status code.
+func NewStringResponse(status int, body string) *http.Response {
+	return &http.Response{
+		Status:     strconv.Itoa(status),
+		StatusCode: status,
+		Body:       NewRespBodyFromString(body),
+		Header:     http.Header{},
+	}
+}
+
+// NewStringResponder creates a Responder from a given body (as a string) and status code.
+func NewStringResponder(status int, body string) Responder {
+	return ResponderFromResponse(NewStringResponse(status, body))
+}
+
+// NewBytesResponse creates an *http.Response with a body based on the given bytes.  Also accepts
+// an http status code.
+func NewBytesResponse(status int, body []byte) *http.Response {
+	return &http.Response{
+		Status:     strconv.Itoa(status),
+		StatusCode: status,
+		Body:       NewRespBodyFromBytes(body),
+		Header:     http.Header{},
+	}
+}
+
+// NewBytesResponder creates a Responder from a given body (as a byte slice) and status code.
+func NewBytesResponder(status int, body []byte) Responder {
+	return ResponderFromResponse(NewBytesResponse(status, body))
+}
+
+// NewJsonResponse creates an *http.Response with a body that is a json encoded representation of
+// the given interface{}.  Also accepts an http status code.
+func NewJsonResponse(status int, body interface{}) (*http.Response, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	response := NewBytesResponse(status, encoded)
+	response.Header.Set("Content-Type", "application/json")
+	return response, nil
+}
+
+// NewJsonResponder creates a Responder from a given body (as an interface{} that is encoded to
+// json) and status code.
+func NewJsonResponder(status int, body interface{}) (Responder, error) {
+	resp, err := NewJsonResponse(status, body)
+	if err != nil {
+		return nil, err
+	}
+	return ResponderFromResponse(resp), nil
+}
+
+// NewXmlResponse creates an *http.Response with a body that is an xml encoded representation
+// of the given interface{}.  Also accepts an http status code.
+func NewXmlResponse(status int, body interface{}) (*http.Response, error) {
+	encoded, err := xml.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	response := NewBytesResponse(status, encoded)
+	response.Header.Set("Content-Type", "application/xml")
+	return response, nil
+}
+
+// NewXmlResponder creates a Responder from a given body (as an interface{} that is encoded to xml)
+// and status code.
+func NewXmlResponder(status int, body interface{}) (Responder, error) {
+	resp, err := NewXmlResponse(status, body)
+	if err != nil {
+		return nil, err
+	}
+	return ResponderFromResponse(resp), nil
+}
+
+// NewRespBodyFromString creates an io.ReadCloser from a string that is suitable for use as an
+// http response body.
+func NewRespBodyFromString(body string) io.ReadCloser {
+	return &dummyReadCloser{strings.NewReader(body)}
+}
+
+// NewRespBodyFromBytes creates an io.ReadCloser from a byte slice that is suitable for use as an
+// http response body.
+func NewRespBodyFromBytes(body []byte) io.ReadCloser {
+	return &dummyReadCloser{bytes.NewReader(body)}
+}
+
+type dummyReadCloser struct {
+	body io.ReadSeeker
+}
+
+func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
+	n, err = d.body.Read(p)
+	if err == io.EOF {
+		d.body.Seek(0, 0)
+	}
+	return n, err
+}
+
+func (d *dummyReadCloser) Close() error {
+	return nil
+}

--- a/vendor/gopkg.in/jarcoal/httpmock.v1/transport.go
+++ b/vendor/gopkg.in/jarcoal/httpmock.v1/transport.go
@@ -1,0 +1,327 @@
+package httpmock
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Responders are callbacks that receive and http request and return a mocked response.
+type Responder func(*http.Request) (*http.Response, error)
+
+// NoResponderFound is returned when no responders are found for a given HTTP method and URL.
+var NoResponderFound = errors.New("no responder found")
+
+// ConnectionFailure is a responder that returns a connection failure.  This is the default
+// responder, and is called when no other matching responder is found.
+func ConnectionFailure(*http.Request) (*http.Response, error) {
+	return nil, NoResponderFound
+}
+
+// NewMockTransport creates a new *MockTransport with no responders.
+func NewMockTransport() *MockTransport {
+	return &MockTransport{
+		responders:    make(map[string]Responder),
+		callCountInfo: make(map[string]int),
+	}
+}
+
+// MockTransport implements http.RoundTripper, which fulfills single http requests issued by
+// an http.Client.  This implementation doesn't actually make the call, instead deferring to
+// the registered list of responders.
+type MockTransport struct {
+	mu             sync.RWMutex
+	responders     map[string]Responder
+	noResponder    Responder
+	callCountInfo  map[string]int
+	totalCallCount int
+}
+
+// RoundTrip receives HTTP requests and routes them to the appropriate responder.  It is required to
+// implement the http.RoundTripper interface.  You will not interact with this directly, instead
+// the *http.Client you are using will call it for you.
+func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.String()
+
+	// try and get a responder that matches the method and URL
+	key := req.Method + " " + url
+	responder := m.responderForKey(key)
+
+	// if we weren't able to find a responder and the URL contains a querystring
+	// then we strip off the querystring and try again.
+	if responder == nil && strings.Contains(url, "?") {
+		key = req.Method + " " + strings.Split(url, "?")[0]
+		responder = m.responderForKey(key)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// if we found a responder, call it
+	if responder != nil {
+		m.callCountInfo[key]++
+		m.totalCallCount++
+		return runCancelable(responder, req)
+	}
+
+	// we didn't find a responder, so fire the 'no responder' responder
+	if m.noResponder == nil {
+		return ConnectionFailure(req)
+	}
+	m.callCountInfo["NO_RESPONDER"]++
+	m.totalCallCount++
+	return runCancelable(m.noResponder, req)
+}
+
+func runCancelable(responder Responder, req *http.Request) (*http.Response, error) {
+	if req.Cancel == nil {
+		return responder(req)
+	}
+
+	// Set up a goroutine that translates a close(req.Cancel) into a
+	// "request canceled" error, and another one that runs the
+	// responder. Then race them: first to the result channel wins.
+
+	type result struct {
+		response *http.Response
+		err      error
+	}
+	resultch := make(chan result, 1)
+	done := make(chan struct{}, 1)
+
+	go func() {
+		select {
+		case <-req.Cancel:
+			resultch <- result{
+				response: nil,
+				err:      errors.New("request canceled"),
+			}
+		case <-done:
+		}
+	}()
+
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				resultch <- result{
+					response: nil,
+					err:      fmt.Errorf("panic in responder: got %q", err),
+				}
+			}
+		}()
+
+		response, err := responder(req)
+		resultch <- result{
+			response: response,
+			err:      err,
+		}
+	}()
+
+	r := <-resultch
+
+	// if a close(req.Cancel) is never coming,
+	// we'll need to unblock the first goroutine.
+	done <- struct{}{}
+
+	return r.response, r.err
+}
+
+// do nothing with timeout
+func (m *MockTransport) CancelRequest(req *http.Request) {}
+
+// responderForKey returns a responder for a given key
+func (m *MockTransport) responderForKey(key string) Responder {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for k, r := range m.responders {
+		if k != key {
+			continue
+		}
+		return r
+	}
+	return nil
+}
+
+// RegisterResponder adds a new responder, associated with a given HTTP method and URL.  When a
+// request comes in that matches, the responder will be called and the response returned to the client.
+func (m *MockTransport) RegisterResponder(method, url string, responder Responder) {
+	key := method + " " + url
+
+	m.mu.Lock()
+	m.responders[key] = responder
+	m.callCountInfo[key] = 0
+	m.mu.Unlock()
+}
+
+// RegisterNoResponder is used to register a responder that will be called if no other responder is
+// found.  The default is ConnectionFailure.
+func (m *MockTransport) RegisterNoResponder(responder Responder) {
+	m.mu.Lock()
+	m.noResponder = responder
+	m.mu.Unlock()
+}
+
+// Reset removes all registered responders (including the no responder) from the MockTransport
+func (m *MockTransport) Reset() {
+	m.mu.Lock()
+	m.responders = make(map[string]Responder)
+	m.noResponder = nil
+	m.callCountInfo = make(map[string]int)
+	m.totalCallCount = 0
+	m.mu.Unlock()
+}
+
+// GetCallCountInfo returns callCountInfo
+func (m *MockTransport) GetCallCountInfo() map[string]int {
+	res := map[string]int{}
+	m.mu.RLock()
+	for k, v := range m.callCountInfo {
+		res[k] = v
+	}
+	m.mu.RUnlock()
+	return res
+}
+
+// GetTotalCallCount returns the totalCallCount
+func (m *MockTransport) GetTotalCallCount() int {
+	m.mu.RLock()
+	count := m.totalCallCount
+	m.mu.RUnlock()
+	return count
+}
+
+// DefaultTransport is the default mock transport used by Activate, Deactivate, Reset,
+// DeactivateAndReset, RegisterResponder, and RegisterNoResponder.
+var DefaultTransport = NewMockTransport()
+
+// InitialTransport is a cache of the original transport used so we can put it back
+// when Deactivate is called.
+var InitialTransport = http.DefaultTransport
+
+// Used to handle custom http clients (i.e clients other than http.DefaultClient)
+var oldTransport http.RoundTripper
+var oldClient *http.Client
+
+// Activate starts the mock environment.  This should be called before your tests run.  Under the
+// hood this replaces the Transport on the http.DefaultClient with DefaultTransport.
+//
+// To enable mocks for a test, simply activate at the beginning of a test:
+// 		func TestFetchArticles(t *testing.T) {
+// 			httpmock.Activate()
+// 			// all http requests will now be intercepted
+// 		}
+//
+// If you want all of your tests in a package to be mocked, just call Activate from init():
+// 		func init() {
+// 			httpmock.Activate()
+// 		}
+func Activate() {
+	if Disabled() {
+		return
+	}
+
+	// make sure that if Activate is called multiple times it doesn't overwrite the InitialTransport
+	// with a mock transport.
+	if http.DefaultTransport != DefaultTransport {
+		InitialTransport = http.DefaultTransport
+	}
+
+	http.DefaultTransport = DefaultTransport
+}
+
+// ActivateNonDefault starts the mock environment with a non-default http.Client.
+// This emulates the Activate function, but allows for custom clients that do not use
+// http.DefaultTransport
+//
+// To enable mocks for a test using a custom client, activate at the beginning of a test:
+// 		client := &http.Client{Transport: &http.Transport{TLSHandshakeTimeout: 60 * time.Second}}
+// 		httpmock.ActivateNonDefault(client)
+func ActivateNonDefault(client *http.Client) {
+	if Disabled() {
+		return
+	}
+
+	// save the custom client & it's RoundTripper
+	oldTransport = client.Transport
+	oldClient = client
+	client.Transport = DefaultTransport
+}
+
+// GetCallCountInfo gets the info on all the calls httpmock has taken since it was activated or
+// reset. The info is returned as a map of the calling keys with the number of calls made to them
+// as their value. The key is the method, a space, and the url all concatenated together.
+func GetCallCountInfo() map[string]int {
+	return DefaultTransport.GetCallCountInfo()
+}
+
+// GetTotalCallCount gets the total number of calls httpmock has taken since it was activated or
+// reset.
+func GetTotalCallCount() int {
+	return DefaultTransport.GetTotalCallCount()
+}
+
+// Deactivate shuts down the mock environment.  Any HTTP calls made after this will use a live
+// transport.
+//
+// Usually you'll call it in a defer right after activating the mock environment:
+// 		func TestFetchArticles(t *testing.T) {
+// 			httpmock.Activate()
+// 			defer httpmock.Deactivate()
+//
+// 			// when this test ends, the mock environment will close
+// 		}
+func Deactivate() {
+	if Disabled() {
+		return
+	}
+	http.DefaultTransport = InitialTransport
+
+	// reset the custom client to use it's original RoundTripper
+	if oldClient != nil {
+		oldClient.Transport = oldTransport
+	}
+}
+
+// Reset will remove any registered mocks and return the mock environment to it's initial state.
+func Reset() {
+	DefaultTransport.Reset()
+}
+
+// DeactivateAndReset is just a convenience method for calling Deactivate() and then Reset()
+// Happy deferring!
+func DeactivateAndReset() {
+	Deactivate()
+	Reset()
+}
+
+// RegisterResponder adds a mock that will catch requests to the given HTTP method and URL, then
+// route them to the Responder which will generate a response to be returned to the client.
+//
+// Example:
+// 		func TestFetchArticles(t *testing.T) {
+// 			httpmock.Activate()
+// 			httpmock.DeactivateAndReset()
+//
+// 			httpmock.RegisterResponder("GET", "http://example.com/",
+// 				httpmock.NewStringResponder("hello world", 200))
+//
+//			// requests to http://example.com/ will now return 'hello world'
+// 		}
+func RegisterResponder(method, url string, responder Responder) {
+	DefaultTransport.RegisterResponder(method, url, responder)
+}
+
+// RegisterNoResponder adds a mock that will be called whenever a request for an unregistered URL
+// is received.  The default behavior is to return a connection error.
+//
+// In some cases you may not want all URLs to be mocked, in which case you can do this:
+// 		func TestFetchArticles(t *testing.T) {
+// 			httpmock.Activate()
+// 			httpmock.DeactivateAndReset()
+//			httpmock.RegisterNoResponder(httpmock.InitialTransport.RoundTrip)
+//
+// 			// any requests that don't have a registered URL will be fetched normally
+// 		}
+func RegisterNoResponder(responder Responder) {
+	DefaultTransport.RegisterNoResponder(responder)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,6 +19,12 @@
 			"path": "github.com/mitchellh/mapstructure",
 			"revision": "53818660ed4955e899c0bcafa97299a388bd7c8e",
 			"revisionTime": "2017-03-07T20:11:23Z"
+		},
+		{
+			"checksumSHA1": "Wx2FYL6OLgZ/9PF1nb+hhNoXcTo=",
+			"path": "gopkg.in/jarcoal/httpmock.v1",
+			"revision": "cf52904a3cf0f78f199ecade6a6df8e245d5b25a",
+			"revisionTime": "2017-04-12T08:57:02Z"
 		}
 	],
 	"rootPath": "github.com/hashicorp/go-oracle-terraform"


### PR DESCRIPTION
Allows `max_retries` to be set during the provider configuration.

```
$ make test TEST=./compute TESTARGS="-v -run=TestClient_retryHTTP"
==> Checking that code complies with gofmt requirements...
==> Checking for unchecked errors...
go test -i ./compute || exit 1
echo ./compute | \
                xargs -t -n4 go test -v -run=TestClient_retryHTTP -timeout=30s -parallel=4
go test -v -run=TestClient_retryHTTP -timeout=30s -parallel=4 ./compute
=== RUN   TestClient_retryHTTP
--- PASS: TestClient_retryHTTP (0.00s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        0.010s
```