### PR TITLE
Adding storage containers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ type Client struct {
 	IdentityDomain *string
 	UserName       *string
 	Password       *string
-	apiEndpoint    *url.URL
+	APIEndpoint    *url.URL
 	httpClient     *http.Client
 	authCookie     *http.Cookie
 	cookieIssued   time.Time
@@ -34,7 +34,7 @@ func NewClient(c *opc.Config) (*Client, error) {
 		IdentityDomain: c.IdentityDomain,
 		UserName:       c.Username,
 		Password:       c.Password,
-		apiEndpoint:    c.APIEndpoint,
+		APIEndpoint:    c.APIEndpoint,
 		httpClient:     c.HTTPClient,
 		maxRetries:     c.MaxRetries,
 		loglevel:       c.LogLevel,
@@ -169,7 +169,7 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) formatURL(path *url.URL) string {
-	return c.apiEndpoint.ResolveReference(path).String()
+	return c.APIEndpoint.ResolveReference(path).String()
 }
 
 // Retry function

--- a/storage/authentication.go
+++ b/storage/authentication.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"fmt"
+	"time"
+)
+
+// Get a new auth token for the storage client
+func (c *StorageClient) getAuthenticationToken() error {
+	var authHeaders map[string]string
+	authHeaders = make(map[string]string)
+	authHeaders["X-Storage-User"] = c.getUserName()
+	authHeaders["X-Storage-Pass"] = *c.client.Password
+
+	rsp, err := c.executeRequest("GET", "/auth/v1.0", authHeaders)
+	if err != nil {
+		return err
+	}
+
+	var authToken string
+	if authToken = rsp.Header.Get("X-Auth-Token"); authToken == "" {
+		return fmt.Errorf("No authentication token found in response %#v", rsp)
+	}
+
+	c.client.DebugLogString("Successfully authenticated to OPC")
+	c.authToken = &authToken
+	c.tokenIssued = time.Now()
+	return nil
+}

--- a/storage/authentication.go
+++ b/storage/authentication.go
@@ -22,7 +22,7 @@ func (c *StorageClient) getAuthenticationToken() error {
 		return fmt.Errorf("No authentication token found in response %#v", rsp)
 	}
 
-	c.client.DebugLogString("Successfully authenticated to OPC")
+	c.client.DebugLogString("Successfully authenticated to IaaS Storage")
 	c.authToken = &authToken
 	c.tokenIssued = time.Now()
 	return nil

--- a/storage/authentication_test.go
+++ b/storage/authentication_test.go
@@ -1,0 +1,22 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+// Test that the client can obtain an authentication cookie from the authentication endpoint.
+func TestAccObtainAuthenticationToken(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	client, err := getStorageTestClient(&opc.Config{})
+	if err != nil {
+		t.Fatalf("Authentication failed: %s", err)
+	}
+
+	if client.authToken == nil {
+		t.Fatal("Authentication token not set")
+	}
+}

--- a/storage/container.go
+++ b/storage/container.go
@@ -17,9 +17,9 @@ type Container struct {
 	// A container access control list (ACL) that grants write access
 	WriteACLs []string
 	// The secret key value for temporary URLs.
-	URLKey string
+	PrimaryKey string
 	// The second secret key value for temporary URLs.
-	URLKey2 string
+	SecondaryKey string
 	// List of origins to be allowed to make cross-origin Requests.
 	AllowedOrigins []string
 	// Maximum age in seconds for the origin to hold the preflight results.
@@ -39,9 +39,9 @@ type CreateContainerInput struct {
 	// Sets a container access control list (ACL) that grants read access.
 	WriteACLs []string
 	// Sets a secret key value for temporary URLs.
-	URLKey string
+	PrimaryKey string
 	// Sets a second secret key value for temporary URLs.
-	URLKey2 string
+	SecondaryKey string
 	// Sets the list of origins allowed to make cross-origin requests.
 	AllowedOrigins []string
 	// Sets the maximum age in seconds for the origin to hold the preflight results.
@@ -62,8 +62,8 @@ func (c *StorageClient) CreateContainer(createInput *CreateContainerInput) (*Con
 		headers["X-Container-Write"] = strings.Join(createInput.WriteACLs, ",")
 	}
 
-	headers["X-Container-Meta-Temp-URL-Key"] = createInput.URLKey
-	headers["X-Container-Meta-Temp-URL-Key-2"] = createInput.URLKey2
+	headers["X-Container-Meta-Temp-URL-Key"] = createInput.PrimaryKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = createInput.SecondaryKey
 	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(createInput.AllowedOrigins, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(createInput.MaxAge)
 
@@ -125,9 +125,9 @@ type UpdateContainerInput struct {
 	// Updates a container access control list (ACL) that grants write access.
 	WriteACLs []string
 	// Updates the secret key value for temporary URLs.
-	URLKey string
+	PrimaryKey string
 	// Update the second secret key value for temporary URLs.
-	URLKey2 string
+	SecondaryKey string
 	// Updates the list of origins allowed to make cross-origin requests.
 	AllowedOrigins []string
 	// Updates the maximum age in seconds for the origin to hold the preflight results.
@@ -146,8 +146,8 @@ func (c *StorageClient) UpdateContainer(updateInput *UpdateContainerInput) (*Con
 		headers["X-Container-Write"] = strings.Join(updateInput.WriteACLs, ",")
 	}
 
-	headers["X-Container-Meta-Temp-URL-Key"] = updateInput.URLKey
-	headers["X-Container-Meta-Temp-URL-Key-2"] = updateInput.URLKey2
+	headers["X-Container-Meta-Temp-URL-Key"] = updateInput.PrimaryKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = updateInput.SecondaryKey
 	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(updateInput.AllowedOrigins, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(updateInput.MaxAge)
 
@@ -166,8 +166,8 @@ func (c *StorageClient) success(rsp *http.Response, container *Container) (*Cont
 	var err error
 	container.ReadACLs = strings.Split(rsp.Header.Get("X-Container-Read"), ",")
 	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
-	container.URLKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
-	container.URLKey2 = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
+	container.PrimaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
+	container.SecondaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
 	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
 	container.MaxAge, err = strconv.Atoi(rsp.Header.Get("X-Container-Meta-Access-Control-Max-Age"))
 	if err != nil {

--- a/storage/container.go
+++ b/storage/container.go
@@ -110,6 +110,8 @@ func (c *StorageClient) GetContainer(getInput *GetContainerInput) (*Container, e
 	if rsp, err = c.getResource(getInput.Name, &container); err != nil {
 		return nil, err
 	}
+	// The response doesn't come back with the name so we need to set it from the Input Name
+	container.Name = c.getUnqualifiedName(getInput.Name)
 	return c.success(rsp, &container)
 }
 
@@ -162,7 +164,6 @@ func (c *StorageClient) UpdateContainer(updateInput *UpdateContainerInput) (*Con
 
 func (c *StorageClient) success(rsp *http.Response, container *Container) (*Container, error) {
 	var err error
-	c.unqualify(&container.Name)
 	container.ReadACLs = strings.Split(rsp.Header.Get("X-Container-Read"), ",")
 	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
 	container.URLKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")

--- a/storage/container.go
+++ b/storage/container.go
@@ -1,0 +1,177 @@
+package storage
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const CONTAINER_VERSION = "v1"
+
+// Container describes an existing Container.
+type Container struct {
+	// The name of the Container
+	Name string
+	// A container access control list (ACL) that grants read access.
+	ReadACLs []string
+	// A container access control list (ACL) that grants write access
+	WriteACLs []string
+	// The secret key value for temporary URLs.
+	URLKey string
+	// The second secret key value for temporary URLs.
+	URLKey2 string
+	// List of origins to be allowed to make cross-origin Requests.
+	AllowedOrigins []string
+	// Maximum age in seconds for the origin to hold the preflight results.
+	MaxAge int
+}
+
+// CreateContainerInput defines an Container to be created.
+type CreateContainerInput struct {
+	// The unique name for the container. The container name must be from 1 to 256 characters long and can
+	// start with any character and contain any pattern. Character set must be UTF-8. The container name
+	// cannot contain a slash (/) character because this character delimits the container and object name.
+	// For example, /account/container/object.
+	// Required
+	Name string `json:"name"`
+	// Sets a container access control list (ACL) that grants read access.
+	ReadACLs []string
+	// Sets a container access control list (ACL) that grants read access.
+	WriteACLs []string
+	// Sets a secret key value for temporary URLs.
+	URLKey string
+	// Sets a second secret key value for temporary URLs.
+	URLKey2 string
+	// Sets the list of origins allowed to make cross-origin requests.
+	AllowedOrigins []string
+	// Sets the maximum age in seconds for the origin to hold the preflight results.
+	MaxAge int
+}
+
+// CreateContainer creates a new Container with the given name, key and enabled flag.
+func (c *StorageClient) CreateContainer(createInput *CreateContainerInput) (*Container, error) {
+	headers := make(map[string]string)
+
+	createInput.Name = c.getQualifiedName(CONTAINER_VERSION, createInput.Name)
+
+	// There are default values for these that we don't want to zero out if Read and Write ACLs are not set.
+	if len(createInput.ReadACLs) > 0 {
+		headers["X-Container-Read"] = strings.Join(createInput.ReadACLs, ",")
+	}
+	if len(createInput.WriteACLs) > 0 {
+		headers["X-Container-Write"] = strings.Join(createInput.WriteACLs, ",")
+	}
+
+	headers["X-Container-Meta-Temp-URL-Key"] = createInput.URLKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = createInput.URLKey2
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(createInput.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(createInput.MaxAge)
+
+	if err := c.createResource(createInput.Name, headers); err != nil {
+		return nil, err
+	}
+
+	getInput := GetContainerInput{
+		Name: createInput.Name,
+	}
+
+	return c.GetContainer(&getInput)
+}
+
+// DeleteKeyInput describes the container to delete
+type DeleteContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:name`
+}
+
+// DeleteContainer deletes the Container with the given name.
+func (c *StorageClient) DeleteContainer(deleteInput *DeleteContainerInput) error {
+	deleteInput.Name = c.getQualifiedName(CONTAINER_VERSION, deleteInput.Name)
+	return c.deleteResource(deleteInput.Name)
+}
+
+// GetContainerInput describes the container to get
+type GetContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:name`
+}
+
+// GetContainer retrieves the Container with the given name.
+func (c *StorageClient) GetContainer(getInput *GetContainerInput) (*Container, error) {
+	var (
+		container Container
+		rsp       *http.Response
+		err       error
+	)
+	getInput.Name = c.getQualifiedName(CONTAINER_VERSION, getInput.Name)
+
+	if rsp, err = c.getResource(getInput.Name, &container); err != nil {
+		return nil, err
+	}
+	return c.success(rsp, &container)
+}
+
+// UpdateContainerInput defines an Container to be updated
+type UpdateContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:"name"`
+	// Updates a container access control list (ACL) that grants read access.
+	ReadACLs []string
+	// Updates a container access control list (ACL) that grants write access.
+	WriteACLs []string
+	// Updates the secret key value for temporary URLs.
+	URLKey string
+	// Update the second secret key value for temporary URLs.
+	URLKey2 string
+	// Updates the list of origins allowed to make cross-origin requests.
+	AllowedOrigins []string
+	// Updates the maximum age in seconds for the origin to hold the preflight results.
+	MaxAge int
+}
+
+// UpdateContainer updates the key and enabled flag of the Container with the given name.
+func (c *StorageClient) UpdateContainer(updateInput *UpdateContainerInput) (*Container, error) {
+	headers := make(map[string]string)
+
+	// There are default values for these that we don't want to zero out if Read and Write ACLs are not set.
+	if len(updateInput.ReadACLs) > 0 {
+		headers["X-Container-Read"] = strings.Join(updateInput.ReadACLs, ",")
+	}
+	if len(updateInput.WriteACLs) > 0 {
+		headers["X-Container-Write"] = strings.Join(updateInput.WriteACLs, ",")
+	}
+
+	headers["X-Container-Meta-Temp-URL-Key"] = updateInput.URLKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = updateInput.URLKey2
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(updateInput.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(updateInput.MaxAge)
+
+	updateInput.Name = c.getQualifiedName(CONTAINER_VERSION, updateInput.Name)
+	if err := c.updateResource(updateInput.Name, headers); err != nil {
+		return nil, err
+	}
+
+	getInput := GetContainerInput{
+		Name: updateInput.Name,
+	}
+	return c.GetContainer(&getInput)
+}
+
+func (c *StorageClient) success(rsp *http.Response, container *Container) (*Container, error) {
+	var err error
+	c.unqualify(&container.Name)
+	container.ReadACLs = strings.Split(rsp.Header.Get("X-Container-Read"), ",")
+	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
+	container.URLKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
+	container.URLKey2 = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
+	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
+	container.MaxAge, err = strconv.Atoi(rsp.Header.Get("X-Container-Meta-Access-Control-Max-Age"))
+	if err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -90,6 +90,9 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if container.Name != _ContainerName {
+		t.Fatalf(fmt.Sprintf("Names don't match. Wanted: %s Recieved: %s", _ContainerName, container.Name))
+	}
 	if !reflect.DeepEqual(container.ReadACLs, updateReadACLs) {
 		t.Fatalf(fmt.Sprintf("UpdatedReadACLs do not match Wanted: %+v Recieved: %+v", container.ReadACLs, updateReadACLs))
 	}

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const _ContainerName = "test-str-container"
+const _ContainerURLKey = "test-url-key"
+const _ContainerURLKey2 = "test-url-key2"
+const _ContainerMaxAge = 50
+
+func TestAccContainerLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	client, err := getStorageTestClient(&opc.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readACLs := []string{"test-read-acl1", "test-read-acl2"}
+	writeACLs := []string{"test-write-acl1", "test-write-acl2"}
+	allowedOrigins := []string{"allowed-origin-1", "allowed-origin-2"}
+
+	createContainerInput := CreateContainerInput{
+		Name:           _ContainerName,
+		ReadACLs:       readACLs,
+		WriteACLs:      writeACLs,
+		URLKey:         _ContainerURLKey,
+		URLKey2:        _ContainerURLKey2,
+		AllowedOrigins: allowedOrigins,
+	}
+
+	createdContainer, err := client.CreateContainer(&createContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully created Container: %+v", createdContainer)
+	defer deleteContainer(t, client, _ContainerName)
+
+	getContainerInput := GetContainerInput{
+		Name: _ContainerName,
+	}
+	container, err := client.GetContainer(&getContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(container.ReadACLs, readACLs) {
+		t.Fatalf(fmt.Sprintf("ReadACLs do not match Wanted: %+v Recieved: %+v", readACLs, container.ReadACLs))
+	}
+	if !reflect.DeepEqual(container.WriteACLs, writeACLs) {
+		t.Fatalf(fmt.Sprintf("WriteACLs do not match Wanted: %+v Recieved: %+v", writeACLs, container.WriteACLs))
+	}
+	if container.URLKey != _ContainerURLKey {
+		t.Fatalf(fmt.Sprintf("URLKeys don't match. Wanted: %s Recieved: %s", _ContainerURLKey, container.URLKey))
+	}
+	if container.URLKey2 != _ContainerURLKey2 {
+		t.Fatalf(fmt.Sprintf("URLKey2 do not match. Wanted: %s Recieved: %s", _ContainerURLKey2, container.URLKey2))
+	}
+	if !reflect.DeepEqual(container.AllowedOrigins, allowedOrigins) {
+		t.Fatalf(fmt.Sprintf("AllowedOrigins do not match Wanted: %+v Recieved: %+v", allowedOrigins, container.AllowedOrigins))
+	}
+
+	log.Print("Successfully retrieved Container")
+
+	updateReadACLs := []string{"test-read-acl3", "test-read-acl4"}
+	updateWriteACLs := []string{"test-write-acl3", "test-write-acl4"}
+	updatedAllowedOrigins := []string{"allowed-origin-3", "allowed-origin-4"}
+	updateContainerInput := UpdateContainerInput{
+		Name:           _ContainerName,
+		ReadACLs:       updateReadACLs,
+		WriteACLs:      updateWriteACLs,
+		URLKey2:        _ContainerURLKey,
+		AllowedOrigins: updatedAllowedOrigins,
+		MaxAge:         _ContainerMaxAge,
+	}
+
+	_, err = client.UpdateContainer(&updateContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully created Container: %+v", createdContainer)
+
+	container, err = client.GetContainer(&getContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(container.ReadACLs, updateReadACLs) {
+		t.Fatalf(fmt.Sprintf("UpdatedReadACLs do not match Wanted: %+v Recieved: %+v", container.ReadACLs, updateReadACLs))
+	}
+	if !reflect.DeepEqual(container.WriteACLs, updateWriteACLs) {
+		t.Fatalf(fmt.Sprintf("UpdatedWriteACLs do not match Wanted: %+v Recieved: %+v", container.WriteACLs, updateWriteACLs))
+	}
+	if container.URLKey != "" {
+		t.Fatalf(fmt.Sprintf("Expected URL Key to be empty. Recieved: %s", container.URLKey))
+	}
+	if container.URLKey2 != _ContainerURLKey {
+		t.Fatalf(fmt.Sprintf("Updated URL Key 2 does not match. Wanted: %s Recieved: %s", _ContainerURLKey, container.URLKey))
+	}
+	if !reflect.DeepEqual(container.AllowedOrigins, updatedAllowedOrigins) {
+		t.Fatalf(fmt.Sprintf("Updated AllowedOrigins do not match Wanted: %+v Recieved: %+v", updatedAllowedOrigins, container.AllowedOrigins))
+	}
+	if container.MaxAge != _ContainerMaxAge {
+		t.Fatalf(fmt.Sprintf("Max Age do not match Wanted: %s Recieved: %s", _ContainerMaxAge, container.MaxAge))
+	}
+
+	log.Print("Successfully retrieved Container")
+}
+
+func deleteContainer(t *testing.T, client *StorageClient, name string) {
+	deleteInput := DeleteContainerInput{
+		Name: name,
+	}
+	if err := client.DeleteContainer(&deleteInput); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Print("Successfully deleted Container")
+}

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 const _ContainerName = "test-str-container"
-const _ContainerURLKey = "test-url-key"
-const _ContainerURLKey2 = "test-url-key2"
+const _ContainerPrimaryKey = "test-url-key"
+const _ContainerSecondaryKey = "test-url-key2"
 const _ContainerMaxAge = 50
 
 func TestAccContainerLifeCycle(t *testing.T) {
@@ -31,8 +31,8 @@ func TestAccContainerLifeCycle(t *testing.T) {
 		Name:           _ContainerName,
 		ReadACLs:       readACLs,
 		WriteACLs:      writeACLs,
-		URLKey:         _ContainerURLKey,
-		URLKey2:        _ContainerURLKey2,
+		PrimaryKey:     _ContainerPrimaryKey,
+		SecondaryKey:   _ContainerSecondaryKey,
 		AllowedOrigins: allowedOrigins,
 	}
 
@@ -56,11 +56,11 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	if !reflect.DeepEqual(container.WriteACLs, writeACLs) {
 		t.Fatalf(fmt.Sprintf("WriteACLs do not match Wanted: %+v Recieved: %+v", writeACLs, container.WriteACLs))
 	}
-	if container.URLKey != _ContainerURLKey {
-		t.Fatalf(fmt.Sprintf("URLKeys don't match. Wanted: %s Recieved: %s", _ContainerURLKey, container.URLKey))
+	if container.PrimaryKey != _ContainerPrimaryKey {
+		t.Fatalf(fmt.Sprintf("URLKeys don't match. Wanted: %s Recieved: %s", _ContainerPrimaryKey, container.PrimaryKey))
 	}
-	if container.URLKey2 != _ContainerURLKey2 {
-		t.Fatalf(fmt.Sprintf("URLKey2 do not match. Wanted: %s Recieved: %s", _ContainerURLKey2, container.URLKey2))
+	if container.SecondaryKey != _ContainerSecondaryKey {
+		t.Fatalf(fmt.Sprintf("URLKey2 do not match. Wanted: %s Recieved: %s", _ContainerSecondaryKey, container.SecondaryKey))
 	}
 	if !reflect.DeepEqual(container.AllowedOrigins, allowedOrigins) {
 		t.Fatalf(fmt.Sprintf("AllowedOrigins do not match Wanted: %+v Recieved: %+v", allowedOrigins, container.AllowedOrigins))
@@ -75,7 +75,7 @@ func TestAccContainerLifeCycle(t *testing.T) {
 		Name:           _ContainerName,
 		ReadACLs:       updateReadACLs,
 		WriteACLs:      updateWriteACLs,
-		URLKey2:        _ContainerURLKey,
+		SecondaryKey:   _ContainerPrimaryKey,
 		AllowedOrigins: updatedAllowedOrigins,
 		MaxAge:         _ContainerMaxAge,
 	}
@@ -99,11 +99,11 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	if !reflect.DeepEqual(container.WriteACLs, updateWriteACLs) {
 		t.Fatalf(fmt.Sprintf("UpdatedWriteACLs do not match Wanted: %+v Recieved: %+v", container.WriteACLs, updateWriteACLs))
 	}
-	if container.URLKey != "" {
-		t.Fatalf(fmt.Sprintf("Expected URL Key to be empty. Recieved: %s", container.URLKey))
+	if container.PrimaryKey != "" {
+		t.Fatalf(fmt.Sprintf("Expected URL Key to be empty. Recieved: %s", container.PrimaryKey))
 	}
-	if container.URLKey2 != _ContainerURLKey {
-		t.Fatalf(fmt.Sprintf("Updated URL Key 2 does not match. Wanted: %s Recieved: %s", _ContainerURLKey, container.URLKey))
+	if container.SecondaryKey != _ContainerPrimaryKey {
+		t.Fatalf(fmt.Sprintf("Updated URL Key 2 does not match. Wanted: %s Recieved: %s", _ContainerPrimaryKey, container.SecondaryKey))
 	}
 	if !reflect.DeepEqual(container.AllowedOrigins, updatedAllowedOrigins) {
 		t.Fatalf(fmt.Sprintf("Updated AllowedOrigins do not match Wanted: %+v Recieved: %+v", updatedAllowedOrigins, container.AllowedOrigins))

--- a/storage/storage_client.go
+++ b/storage/storage_client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -109,10 +108,4 @@ func (c *StorageClient) unqualify(names ...*string) {
 	for _, name := range names {
 		*name = c.getUnqualifiedName(*name)
 	}
-}
-
-func (c *StorageClient) unqualifyUrl(url *string) {
-	var validID = regexp.MustCompile(`(\/(Compute[^\/\s]+))(\/[^\/\s]+)(\/[^\/\s]+)`)
-	name := validID.FindString(*url)
-	*url = c.getUnqualifiedName(name)
 }

--- a/storage/storage_client.go
+++ b/storage/storage_client.go
@@ -1,0 +1,122 @@
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const STR_ACCOUNT = "/Storage-%s"
+const STR_USERNAME = "/Storage-%s:%s"
+const AUTH_HEADER = "X-Auth-Token"
+const STR_QUALIFIED_NAME = "%s%s/%s"
+
+// Client represents an authenticated compute client, with compute credentials and an api client.
+type StorageClient struct {
+	client      *client.Client
+	authToken   *string
+	tokenIssued time.Time
+}
+
+func NewStorageClient(c *opc.Config) (*StorageClient, error) {
+	storageClient := &StorageClient{}
+	client, err := client.NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+	storageClient.client = client
+
+	storageClient.client.APIEndpoint, err = url.Parse(fmt.Sprintf("https://%s.storage.oraclecloud.com", *client.IdentityDomain))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := storageClient.getAuthenticationToken(); err != nil {
+		return nil, err
+	}
+
+	return storageClient, nil
+}
+
+func (c *StorageClient) executeRequest(method, path string, headers interface{}) (*http.Response, error) {
+	req, err := c.client.BuildRequest(method, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if headers != nil {
+		for k, v := range headers.(map[string]string) {
+			req.Header.Add(k, v)
+		}
+	}
+
+	// If we have an authentication token, let's authenticate, refreshing cookie if need be
+	if c.authToken != nil {
+		if time.Since(c.tokenIssued).Minutes() > 25 {
+			if err := c.getAuthenticationToken(); err != nil {
+				return nil, err
+			}
+		}
+		req.Header.Add(AUTH_HEADER, *c.authToken)
+	}
+
+	resp, err := c.client.ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *StorageClient) getUserName() string {
+	return fmt.Sprintf(STR_USERNAME, *c.client.IdentityDomain, *c.client.UserName)
+}
+
+func (c *StorageClient) getAccount() string {
+	return fmt.Sprintf(STR_ACCOUNT, *c.client.IdentityDomain)
+}
+
+// From compute_client
+// GetObjectName returns the fully-qualified name of an OPC object, e.g. /identity-domain/user@email/{name}
+func (c *StorageClient) getQualifiedName(version string, name string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "/Storage-") || strings.HasPrefix(name, "v1/") {
+		return name
+	}
+	return fmt.Sprintf(STR_QUALIFIED_NAME, version, c.getAccount(), name)
+}
+
+// GetUnqualifiedName returns the unqualified name of an OPC object, e.g. the {name} part of /identity-domain/user@email/{name}
+func (c *StorageClient) getUnqualifiedName(name string) string {
+	if name == "" {
+		return name
+	}
+	if strings.HasPrefix(name, "/oracle") {
+		return name
+	}
+	if !strings.Contains(name, "/") {
+		return name
+	}
+
+	nameParts := strings.Split(name, "/")
+	return strings.Join(nameParts[3:], "/")
+}
+
+func (c *StorageClient) unqualify(names ...*string) {
+	for _, name := range names {
+		*name = c.getUnqualifiedName(*name)
+	}
+}
+
+func (c *StorageClient) unqualifyUrl(url *string) {
+	var validID = regexp.MustCompile(`(\/(Compute[^\/\s]+))(\/[^\/\s]+)(\/[^\/\s]+)`)
+	name := validID.FindString(*url)
+	*url = c.getUnqualifiedName(name)
+}

--- a/storage/storage_client.go
+++ b/storage/storage_client.go
@@ -81,8 +81,7 @@ func (c *StorageClient) getAccount() string {
 	return fmt.Sprintf(STR_ACCOUNT, *c.client.IdentityDomain)
 }
 
-// From compute_client
-// GetObjectName returns the fully-qualified name of an OPC object, e.g. /identity-domain/user@email/{name}
+// GetQualifiedName returns the fully-qualified name of a storage object, e.g. /v1/{account}/{name}
 func (c *StorageClient) getQualifiedName(version string, name string) string {
 	if name == "" {
 		return ""
@@ -93,12 +92,9 @@ func (c *StorageClient) getQualifiedName(version string, name string) string {
 	return fmt.Sprintf(STR_QUALIFIED_NAME, version, c.getAccount(), name)
 }
 
-// GetUnqualifiedName returns the unqualified name of an OPC object, e.g. the {name} part of /identity-domain/user@email/{name}
+// GetUnqualifiedName returns the unqualified name of a Storage object, e.g. the {name} part of /v1/{account}/{name}
 func (c *StorageClient) getUnqualifiedName(name string) string {
 	if name == "" {
-		return name
-	}
-	if strings.HasPrefix(name, "/oracle") {
 		return name
 	}
 	if !strings.Contains(name, "/") {
@@ -106,7 +102,7 @@ func (c *StorageClient) getUnqualifiedName(name string) string {
 	}
 
 	nameParts := strings.Split(name, "/")
-	return strings.Join(nameParts[3:], "/")
+	return strings.Join(nameParts[2:], "/")
 }
 
 func (c *StorageClient) unqualify(names ...*string) {

--- a/storage/storage_resource_client.go
+++ b/storage/storage_resource_client.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"net/http"
+)
+
+func (c *StorageClient) createResource(name string, requestHeaders interface{}) error {
+	_, err := c.executeRequest("PUT", name, requestHeaders)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *StorageClient) updateResource(name string, requestHeaders interface{}) error {
+	_, err := c.executeRequest("PUT", name, requestHeaders)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *StorageClient) getResource(name string, responseBody interface{}) (*http.Response, error) {
+	rsp, err := c.executeRequest("GET", name, nil)
+	if err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *StorageClient) deleteResource(name string) error {
+	_, err := c.executeRequest("DELETE", name, nil)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}

--- a/storage/test_utils.go
+++ b/storage/test_utils.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_ClientTestUser   = "test-user"
+	_ClientTestDomain = "test-domain"
+)
+
+func newAuthenticatingServer(handler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if os.Getenv("ORACLE_LOG") != "" {
+			log.Printf("[DEBUG] Received request: %s, %s\n", r.Method, r.URL)
+		}
+
+		if r.URL.Path == "/authenticate/" {
+			http.SetCookie(w, &http.Cookie{Name: "testAuthCookie", Value: "cookie value"})
+			//	w.WriteHeader(200)
+		} else {
+			handler(w, r)
+		}
+	}))
+}
+
+func getStorageTestClient(c *opc.Config) (*StorageClient, error) {
+	// Build up config with default values if omitted
+
+	if c.IdentityDomain == nil {
+		domain := os.Getenv("OPC_IDENTITY_DOMAIN")
+		c.IdentityDomain = &domain
+	}
+
+	if c.Username == nil {
+		username := os.Getenv("OPC_USERNAME")
+		c.Username = &username
+	}
+
+	if c.Password == nil {
+		password := os.Getenv("OPC_PASSWORD")
+		c.Password = &password
+	}
+
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				TLSHandshakeTimeout: 120 * time.Second},
+		}
+	}
+
+	return NewStorageClient(c)
+}
+
+func getBlankTestClient() (*StorageClient, *httptest.Server, error) {
+	server := newAuthenticatingServer(func(w http.ResponseWriter, r *http.Request) {
+	})
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		server.Close()
+		return nil, nil, err
+	}
+
+	client, err := getStorageTestClient(&opc.Config{
+		IdentityDomain: opc.String(_ClientTestDomain),
+		Username:       opc.String(_ClientTestUser),
+		APIEndpoint:    endpoint,
+	})
+	if err != nil {
+		server.Close()
+		return nil, nil, err
+	}
+	return client, server, nil
+}
+
+// Returns a stub client with default values, and a custom API Endpoint
+func getStubClient(endpoint *url.URL) (*StorageClient, error) {
+	domain := "test"
+	username := "test"
+	password := "test"
+	config := &opc.Config{
+		IdentityDomain: &domain,
+		Username:       &username,
+		Password:       &password,
+		APIEndpoint:    endpoint,
+	}
+	return getStorageTestClient(config)
+}
+
+func unmarshalRequestBody(t *testing.T, r *http.Request, target interface{}) {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r.Body)
+	err := json.Unmarshal(buf.Bytes(), target)
+	if err != nil {
+		t.Fatalf("Error marshalling request: %s", err)
+	}
+}


### PR DESCRIPTION
This PR adds the first PaaS resource (Storage containers) to the oracle sdk. 

```
TF_ACC=1 make test TEST=./storage TESTARGS="-v -run=TestAccContainerLifeCycle"
==> Checking that code complies with gofmt requirements...
==> Checking for unchecked errors...
go test -i ./storage || exit 1
echo ./storage | \
		xargs -t -n4 go test -v -run=TestAccContainerLifeCycle -timeout=60m -parallel=4
go test -v -run=TestAccContainerLifeCycle -timeout=60m -parallel=4 ./storage
=== RUN   TestAccContainerLifeCycle
--- PASS: TestAccContainerLifeCycle (1.89s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/storage	1.914s
```
