### PR TITLE
P instance retry

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,7 @@ type Client struct {
 	Password       *string
 	APIEndpoint    *url.URL
 	httpClient     *http.Client
-	maxRetries     *int
+	MaxRetries     *int
 	logger         opc.Logger
 	loglevel       opc.LogLevelType
 }
@@ -34,7 +34,7 @@ func NewClient(c *opc.Config) (*Client, error) {
 		Password:       c.Password,
 		APIEndpoint:    c.APIEndpoint,
 		httpClient:     c.HTTPClient,
-		maxRetries:     c.MaxRetries,
+		MaxRetries:     c.MaxRetries,
 		loglevel:       c.LogLevel,
 	}
 
@@ -53,7 +53,7 @@ func NewClient(c *opc.Config) (*Client, error) {
 
 	// Default max retries if unset
 	if c.MaxRetries == nil {
-		client.maxRetries = opc.Int(DEFAULT_MAX_RETRIES)
+		client.MaxRetries = opc.Int(DEFAULT_MAX_RETRIES)
 	}
 
 	// Protect against any nil http client
@@ -130,10 +130,10 @@ func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 	// Double check maxRetries is not nil
 	var retries int
-	if c.maxRetries == nil {
+	if c.MaxRetries == nil {
 		retries = DEFAULT_MAX_RETRIES
 	} else {
-		retries = *c.maxRetries
+		retries = *c.MaxRetries
 	}
 
 	var statusCode int

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -320,40 +320,51 @@ func (c *InstancesClient) CreateInstance(input *CreateInstanceInput) (*InstanceI
 	plan := LaunchPlanInput{Instances: []CreateInstanceInput{*input}}
 
 	var (
-		responseBody  LaunchPlanResponse
+		instanceInfo  *InstanceInfo
 		instanceError error
 	)
 	for i := 0; i < *c.ComputeClient.client.MaxRetries; i++ {
-		if err := c.createResource(&plan, &responseBody); err != nil {
-			return nil, err
+		instanceInfo, instanceError = c.startInstance(input.Name, plan)
+		if instanceError == nil {
+			return instanceInfo, nil
 		}
-
-		if len(responseBody.Instances) == 0 {
-			return nil, fmt.Errorf("No instance information returned: %#v", responseBody)
-		}
-
-		// Call wait for instance ready now, as creating the instance is an eventually consistent operation
-		getInput := &GetInstanceInput{
-			Name: input.Name,
-			ID:   responseBody.Instances[0].ID,
-		}
-
-		// Wait for instance to be ready and return the result
-		// Don't have to unqualify any objects, as the GetInstance method will handle that
-		instanceInfo, instanceError := c.WaitForInstanceRunning(getInput, WaitForInstanceReadyTimeout)
-		// If the instance enters an error state we need to delete the instance and retry
-		if instanceError != nil {
-			deleteInput := &DeleteInstanceInput{
-				Name: input.Name,
-			}
-			err := c.DeleteInstance(deleteInput)
-			if err != nil {
-				return nil, fmt.Errorf("Error deleting instance %s: %s", input.Name, err)
-			}
-		}
-		return instanceInfo, nil
 	}
 	return nil, instanceError
+}
+
+func (c *InstancesClient) startInstance(name string, plan LaunchPlanInput) (*InstanceInfo, error) {
+	var responseBody LaunchPlanResponse
+
+	if err := c.createResource(&plan, &responseBody); err != nil {
+		return nil, err
+	}
+
+	if len(responseBody.Instances) == 0 {
+		return nil, fmt.Errorf("No instance information returned: %#v", responseBody)
+	}
+
+	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	getInput := &GetInstanceInput{
+		Name: name,
+		ID:   responseBody.Instances[0].ID,
+	}
+
+	// Wait for instance to be ready and return the result
+	// Don't have to unqualify any objects, as the GetInstance method will handle that
+	instanceInfo, instanceError := c.WaitForInstanceRunning(getInput, WaitForInstanceReadyTimeout)
+	// If the instance enters an error state we need to delete the instance and retry
+	if instanceError != nil {
+		deleteInput := &DeleteInstanceInput{
+			Name: name,
+			ID:   responseBody.Instances[0].ID,
+		}
+		err := c.DeleteInstance(deleteInput)
+		if err != nil {
+			return nil, fmt.Errorf("Error deleting instance %s: %s", name, err)
+		}
+		return nil, instanceError
+	}
+	return instanceInfo, nil
 }
 
 // Both of these fields are required. If they're not provided, things go wrong in

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -54,7 +54,7 @@ func TestAccContainerLifeCycle(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("ReadACL diff (-got +want)\n%s", diff))
 	}
 	if diff := pretty.Compare(container.WriteACLs, writeACLs); diff != "" {
-		t.Fatalf(fmt.Sprintf("WriteACL diff (-got +want)\n%s", diff)
+		t.Fatalf(fmt.Sprintf("WriteACL diff (-got +want)\n%s", diff))
 	}
 	if container.PrimaryKey != _ContainerPrimaryKey {
 		t.Fatalf(fmt.Sprintf("URLKeys don't match. Wanted: %s Recieved: %s", _ContainerPrimaryKey, container.PrimaryKey))


### PR DESCRIPTION
This PR adds logic to tear down and recreate an instance that is in an errored state 

```
make test TEST=./compute TESTARGS="-v -run=TestInstanceClient_CreateInstanceError"
==> Checking that code complies with gofmt requirements...
==> Checking for unchecked errors...
go test -i ./compute || exit 1
echo ./compute | \
		xargs -t -n4 go test -v -run=TestInstanceClient_CreateInstanceError -timeout=60m -parallel=4
go test -v -run=TestInstanceClient_CreateInstanceError -timeout=60m -parallel=4 ./compute
=== RUN   TestInstanceClient_CreateInstanceError
--- PASS: TestInstanceClient_CreateInstanceError (2.01s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	2.035s
```