### PR TITLE
Storage URL

### DIFF
--- a/storage/storage_client.go
+++ b/storage/storage_client.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -29,12 +28,6 @@ func NewStorageClient(c *opc.Config) (*StorageClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	endpoint, err := url.Parse(fmt.Sprintf("https://%s.storage.oraclecloud.com", *client.IdentityDomain))
-	if err != nil {
-		return nil, err
-	}
-	client.APIEndpoint = endpoint
 	storageClient.client = client
 
 	if err := storageClient.getAuthenticationToken(); err != nil {

--- a/storage/test_utils.go
+++ b/storage/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"time"
 
@@ -45,6 +46,14 @@ func getStorageTestClient(c *opc.Config) (*StorageClient, error) {
 	if c.Password == nil {
 		password := os.Getenv("OPC_PASSWORD")
 		c.Password = &password
+	}
+
+	if c.APIEndpoint == nil {
+		apiEndpoint, err := url.Parse(os.Getenv("OPC_STORAGE_ENDPOINT"))
+		if err != nil {
+			return nil, err
+		}
+		c.APIEndpoint = apiEndpoint
 	}
 
 	if c.HTTPClient == nil {


### PR DESCRIPTION
This PR switches the sdk from building the url to the user passing their storage url through the `Config` struct or through the `OPC_STORAGE_ENDPOINT` flag

```
make test TEST=./storage TESTARGS="-v -run=TestAcc"
==> Checking that code complies with gofmt requirements...
==> Checking for unchecked errors...
go test -i ./storage || exit 1
echo ./storage | \
		xargs -t -n4 go test -v -run=TestAcc -timeout=60m -parallel=4
go test -v -run=TestAcc -timeout=60m -parallel=4 ./storage
=== RUN   TestAccObtainAuthenticationToken
--- PASS: TestAccObtainAuthenticationToken (0.60s)
=== RUN   TestAccContainerLifeCycle
--- PASS: TestAccContainerLifeCycle (1.88s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/storage	2.512s
```