### PR TITLE
Add timeouts, update WaitFor()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -171,8 +171,10 @@ func (c *Client) formatURL(path *url.URL) string {
 }
 
 // Retry function
-func (c *Client) WaitFor(description string, timeoutSeconds int, test func() (bool, error)) error {
+func (c *Client) WaitFor(description string, timeout time.Duration, test func() (bool, error)) error {
 	tick := time.Tick(1 * time.Second)
+
+	timeoutSeconds := int(timeout.Seconds())
 
 	for i := 0; i < timeoutSeconds; i++ {
 		select {

--- a/compute/instances_integration_test.go
+++ b/compute/instances_integration_test.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
@@ -149,6 +150,8 @@ func TestAccInstanceLifeCycle(t *testing.T) {
 
 // Test that we can shutdown and startup an instance
 func TestAccInstanceStopStart(t *testing.T) {
+	rInt := rand.Int()
+
 	helper.Test(t, helper.TestCase{})
 
 	// Setup Instance Client
@@ -183,7 +186,7 @@ func TestAccInstanceStopStart(t *testing.T) {
 	defer destroyImageListEntry(t, eClient, createdListEntry)
 
 	// Create the bootable storage volume
-	volumeName := fmt.Sprintf("%s-volume", _InstanceTestName)
+	volumeName := fmt.Sprintf("%s-volume-%d", _InstanceTestName, rInt)
 	volumeInput := &CreateStorageVolumeInput{
 		Name:           volumeName,
 		Size:           "20",

--- a/compute/ssh_keys_test.go
+++ b/compute/ssh_keys_test.go
@@ -13,13 +13,15 @@ import (
 func TestAccSSHClient_CreateKey(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 	server := newAuthenticatingServer(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			t.Errorf("Wrong HTTP method %s, expected POST", r.Method)
+		if r.Method != "POST" && r.Method != "PUT" {
+			t.Errorf("Wrong HTTP method %s, expected POST or PUT", r.Method)
 		}
 
-		expectedPath := "/sshkey/"
-		if r.URL.Path != expectedPath {
-			t.Errorf("Wrong HTTP URL %v, expected %v", r.URL, expectedPath)
+		expectedCreatePath := "/sshkey/"
+		expectedUpdatePath := "/sshkey/Compute-test/test/test-key1"
+		if r.URL.Path != expectedCreatePath && r.URL.Path != expectedUpdatePath {
+			t.Errorf("Wrong HTTP URL %v, expected %v or %v",
+				r.URL, expectedCreatePath, expectedUpdatePath)
 		}
 
 		keyInfo := &SSHKey{}

--- a/compute/storage_volume_attachments_test.go
+++ b/compute/storage_volume_attachments_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
 )
@@ -22,7 +23,7 @@ func TestAccStorageAttachmentsClient_WaitForStorageDetachmentSuccessful(t *testi
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	err = sv.waitForStorageAttachmentToBeDeleted(name, 10)
+	err = sv.waitForStorageAttachmentToBeDeleted(name, time.Duration(10*time.Second))
 	if err != nil {
 		t.Fatalf("Wait for storage attachment to become detach request failed: %s", err)
 	}
@@ -41,7 +42,7 @@ func TestAccStorageAttachmentsClient_WaitForStorageDetachmentTimeout(t *testing.
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	err = sv.waitForStorageAttachmentToBeDeleted(name, 3)
+	err = sv.waitForStorageAttachmentToBeDeleted(name, time.Duration(3*time.Second))
 	if err == nil {
 		t.Fatal("Expected timeout error")
 	}
@@ -59,7 +60,7 @@ func TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedSu
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	info, err := sv.waitForStorageAttachmentToFullyAttach(name, 10)
+	info, err := sv.waitForStorageAttachmentToFullyAttach(name, time.Duration(10*time.Second))
 	if err != nil {
 		t.Fatalf("Wait for storage attachment to become available request failed: %s", err)
 	}
@@ -83,7 +84,7 @@ func TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedTi
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	_, err = sv.waitForStorageAttachmentToFullyAttach(name, 3)
+	_, err = sv.waitForStorageAttachmentToFullyAttach(name, time.Duration(3*time.Second))
 	if err == nil {
 		t.Fatal("Expected timeout error")
 	}

--- a/compute/storage_volumes_test.go
+++ b/compute/storage_volumes_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
 )
@@ -22,7 +23,7 @@ func TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful(t *tes
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	err = sv.waitForStorageVolumeToBeDeleted(name, 10)
+	err = sv.waitForStorageVolumeToBeDeleted(name, time.Duration(10*time.Second))
 	if err != nil {
 		t.Fatalf("Wait for storage volume deleted request failed: %s", err)
 	}
@@ -51,7 +52,7 @@ func TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout(t *testin
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	err = sv.waitForStorageVolumeToBeDeleted(name, 3)
+	err = sv.waitForStorageVolumeToBeDeleted(name, time.Duration(3*time.Second))
 	if err == nil {
 		t.Fatal("Expected timeout error")
 	}
@@ -67,7 +68,7 @@ func TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful(
 		t.Fatalf("error getting stub client: %s", err)
 	}
 
-	info, err := sv.waitForStorageVolumeToBecomeAvailable("test", 10)
+	info, err := sv.waitForStorageVolumeToBecomeAvailable("test", time.Duration(10*time.Second))
 	if err != nil {
 		t.Fatalf("Wait for storage volume online request failed: %s", err)
 	}
@@ -87,7 +88,7 @@ func TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout(t *
 	if err != nil {
 		t.Fatalf("error getting stub client: %s", err)
 	}
-	_, err = sv.waitForStorageVolumeToBecomeAvailable("test", 3)
+	_, err = sv.waitForStorageVolumeToBecomeAvailable("test", time.Duration(3*time.Second))
 	if err == nil {
 		t.Fatal("Expected timeout error")
 	}


### PR DESCRIPTION
Add timeouts to input structs to allow setting timeouts inside the TF provider, which is the first step to adding timeouts to the OPC provider.

Next step is to setup timeouts in the provider.

```
$ make testacc TEST=./compute
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute  -timeout 120m
=== RUN   TestAccACLLifeCycle
--- PASS: TestAccACLLifeCycle (5.56s)
=== RUN   TestAccACLsClient_CreateRule
--- PASS: TestAccACLsClient_CreateRule (0.00s)
=== RUN   TestAccObtainAuthenticationCookie
--- PASS: TestAccObtainAuthenticationCookie (0.00s)
=== RUN   TestAccAuthenticationCookieSentInRequestsFromAuthenticatedClient
--- PASS: TestAccAuthenticationCookieSentInRequestsFromAuthenticatedClient (0.00s)
=== RUN   TestClient_qualifyList
--- PASS: TestClient_qualifyList (0.00s)
=== RUN   TestAccImageListEntriesLifeCycle
--- PASS: TestAccImageListEntriesLifeCycle (6.75s)
=== RUN   TestAccImageListLifeCycle
--- PASS: TestAccImageListLifeCycle (2.66s)
=== RUN   TestAccInstanceLifeCycle
--- PASS: TestAccInstanceLifeCycle (597.37s)
=== RUN   TestAccInstanceStopStart
--- PASS: TestAccInstanceStopStart (397.47s)
=== RUN   TestInstanceClient_CreateInstance
--- PASS: TestInstanceClient_CreateInstance (1.00s)
=== RUN   TestInstanceClient_CreateInstanceError
--- PASS: TestInstanceClient_CreateInstanceError (2.01s)
=== RUN   TestInstanceClient_RetrieveInstance
--- PASS: TestInstanceClient_RetrieveInstance (0.00s)
=== RUN   TestAccIPAddressAssociationsLifeCycle
--- PASS: TestAccIPAddressAssociationsLifeCycle (118.81s)
=== RUN   TestAccIPAddressPrefixSetsLifeCycle
--- PASS: TestAccIPAddressPrefixSetsLifeCycle (4.58s)
=== RUN   TestAccIPAddressReservationLifeCycle
--- PASS: TestAccIPAddressReservationLifeCycle (5.76s)
=== RUN   TestAccIPAssociationLifeCycle
--- PASS: TestAccIPAssociationLifeCycle (261.08s)
=== RUN   TestAccIPNetworkExchangesLifeCycle
--- PASS: TestAccIPNetworkExchangesLifeCycle (3.57s)
=== RUN   TestAccIPNetworksLifeCycle
--- PASS: TestAccIPNetworksLifeCycle (6.06s)
=== RUN   TestAccIPNetworksWithExchangesLifeCycle
--- PASS: TestAccIPNetworksWithExchangesLifeCycle (5.54s)
=== RUN   TestAccIPReservationLifeCycle
--- PASS: TestAccIPReservationLifeCycle (5.55s)
=== RUN   TestAccRoutesLifeCycle
--- PASS: TestAccRoutesLifeCycle (116.32s)
=== RUN   TestRoutesClient_CreateRoute
--- PASS: TestRoutesClient_CreateRoute (0.00s)
=== RUN   TestAccSecRuleLifeCycle
--- PASS: TestAccSecRuleLifeCycle (7.67s)
=== RUN   TestAccSecRulesClient_CreateRule
--- PASS: TestAccSecRulesClient_CreateRule (0.00s)
=== RUN   TestAccSecurityApplicationsTCPLifeCycle
--- PASS: TestAccSecurityApplicationsTCPLifeCycle (2.07s)
=== RUN   TestAccSecurityApplicationsICMPLifeCycle
--- PASS: TestAccSecurityApplicationsICMPLifeCycle (2.46s)
=== RUN   TestAccSecurityAssociationLifeCycle
--- PASS: TestAccSecurityAssociationLifeCycle (301.05s)
=== RUN   TestAccSecurityIPListLifeCycle
--- PASS: TestAccSecurityIPListLifeCycle (4.09s)
=== RUN   TestAccSecurityIPListsClient_CreateKey
--- PASS: TestAccSecurityIPListsClient_CreateKey (0.00s)
=== RUN   TestAccSecurityListLifeCycle
--- PASS: TestAccSecurityListLifeCycle (2.62s)
=== RUN   TestAccSecurityListsClient_CreateKey
--- PASS: TestAccSecurityListsClient_CreateKey (0.00s)
=== RUN   TestAccSecurityProtocolsLifeCycle
--- PASS: TestAccSecurityProtocolsLifeCycle (6.28s)
=== RUN   TestAccSecurityRulesLifeCycle
--- PASS: TestAccSecurityRulesLifeCycle (6.08s)
=== RUN   TestAccSecurityRulesWithOptionsLifeCycle
--- PASS: TestAccSecurityRulesWithOptionsLifeCycle (11.77s)
=== RUN   TestAccSnapshotLifeCycleBasic
--- PASS: TestAccSnapshotLifeCycleBasic (487.23s)
=== RUN   TestAccSnapshotLifeCycleMachineImage
--- PASS: TestAccSnapshotLifeCycleMachineImage (175.43s)
=== RUN   TestAccSnapshotLifeCycleDelay
--- PASS: TestAccSnapshotLifeCycleDelay (159.42s)
=== RUN   TestAccSnapshotLifeCycleAccount
--- PASS: TestAccSnapshotLifeCycleAccount (186.61s)
=== RUN   TestAccSSHKeyLifeCycle
--- PASS: TestAccSSHKeyLifeCycle (5.87s)
=== RUN   TestAccSSHClient_CreateKey
--- PASS: TestAccSSHClient_CreateKey (0.00s)
=== RUN   TestAccStorageAttachmentsLifecycle
--- PASS: TestAccStorageAttachmentsLifecycle (284.24s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageDetachmentSuccessful
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageDetachmentSuccessful (4.00s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageDetachmentTimeout
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageDetachmentTimeout (3.00s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedSuccessful
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedSuccessful (4.00s)
=== RUN   TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedTimeout
--- PASS: TestAccStorageAttachmentsClient_WaitForStorageAttachmentToBeFullyAttachedTimeout (3.00s)
=== RUN   TestAccStorageVolumeSnapshot_Lifecycle
--- PASS: TestAccStorageVolumeSnapshot_Lifecycle (10.81s)
=== RUN   TestAccStorageVolumeLifecycle
--- PASS: TestAccStorageVolumeLifecycle (10.86s)
=== RUN   TestAccStorageVolumeBootableLifecycle
--- PASS: TestAccStorageVolumeBootableLifecycle (23.67s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedSuccessful (4.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBeDeletedTimeout (3.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableSuccessful (4.00s)
=== RUN   TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout
--- PASS: TestAccStorageVolumeClient_WaitForStorageVolumeToBecomeAvailableTimeout (3.00s)
=== RUN   TestAccVirtNICSetsLifeCycle
--- PASS: TestAccVirtNICSetsLifeCycle (9.22s)
=== RUN   TestAccVirtNICSetsAddNICS
--- PASS: TestAccVirtNICSetsAddNICS (128.23s)
=== RUN   TestAccVirtNICLifeCycle
--- PASS: TestAccVirtNICLifeCycle (125.80s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/compute        3519.631s
```