### PR TITLE
Add database service instance

### DIFF
--- a/database/authentication.go
+++ b/database/authentication.go
@@ -1,0 +1,13 @@
+package database
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Get a new auth token for the storage client
+func (c *DatabaseClient) getAuthenticationHeader() *string {
+	usernamePassword := []byte(fmt.Sprintf("%s:%s", *c.client.UserName, *c.client.Password))
+	authToken := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(usernamePassword))
+	return &authToken
+}

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -1,0 +1,105 @@
+package database
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const DB_ACCOUNT = "/Database-%s"
+const DB_USERNAME = "/Database-%s:%s"
+const AUTH_HEADER = "Authorization"
+const TENANT_HEADER = "X-ID-TENANT-NAME"
+const DB_QUALIFIED_NAME = "%s%s/%s"
+
+// Client represents an authenticated database client, with compute credentials and an api client.
+type DatabaseClient struct {
+	client     *client.Client
+	authHeader *string
+}
+
+func NewDatabaseClient(c *opc.Config) (*DatabaseClient, error) {
+	databaseClient := &DatabaseClient{}
+	client, err := client.NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+	databaseClient.client = client
+
+	databaseClient.authHeader = databaseClient.getAuthenticationHeader()
+
+	return databaseClient, nil
+}
+
+func (c *DatabaseClient) executeRequest(method, path string, body interface{}) (*http.Response, error) {
+	req, err := c.client.BuildRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	debugReqString := fmt.Sprintf("HTTP %s Req (%s)", method, path)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// Log the request before the authentication header, so as not to leak credentials
+	c.client.DebugLogString(debugReqString)
+
+	// Set the authentiation headers
+	req.Header.Add(AUTH_HEADER, *c.authHeader)
+	req.Header.Add(TENANT_HEADER, *c.client.IdentityDomain)
+	c.client.DebugLogString(fmt.Sprintf("Req (%+v)", req))
+	resp, err := c.client.ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *DatabaseClient) getUserName() string {
+	return fmt.Sprintf(DB_USERNAME, *c.client.IdentityDomain, *c.client.UserName)
+}
+
+func (c *DatabaseClient) getAccount() string {
+	return fmt.Sprintf(DB_ACCOUNT, *c.client.IdentityDomain)
+}
+
+// GetQualifiedName returns the fully-qualified name of a database object, e.g. /v1/{account}/{name}
+func (c *DatabaseClient) getQualifiedName(version string, name string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "/Database-") || strings.HasPrefix(name, "v1/") {
+		return name
+	}
+	return fmt.Sprintf(DB_QUALIFIED_NAME, version, c.getAccount(), name)
+}
+
+// GetUnqualifiedName returns the unqualified name of a Database object, e.g. the {name} part of /v1/{account}/{name}
+func (c *DatabaseClient) getUnqualifiedName(name string) string {
+	if name == "" {
+		return name
+	}
+	if !strings.Contains(name, "/") {
+		return name
+	}
+
+	nameParts := strings.Split(name, "/")
+	return strings.Join(nameParts[len(nameParts)-1:], "/")
+}
+
+func (c *DatabaseClient) unqualify(names ...*string) {
+	for _, name := range names {
+		*name = c.getUnqualifiedName(*name)
+	}
+}
+
+func (c *DatabaseClient) getContainerPath(root string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain)
+}
+
+func (c *DatabaseClient) getObjectPath(root, name string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain, name)
+}

--- a/database/database_resource_client.go
+++ b/database/database_resource_client.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// ResourceClient is an AuthenticatedClient with some additional information about the resources to be addressed.
+type ResourceClient struct {
+	*DatabaseClient
+	ContainerPath    string
+	ResourceRootPath string
+}
+
+func (c *ResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *ResourceClient) deleteResource(name string) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	_, err := c.executeRequest("DELETE", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}
+
+func (c *ResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err := dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("%+v", resp)
+		return err
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -1,0 +1,563 @@
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+)
+
+const WaitForServiceInstanceReadyTimeout = 3600
+const WaitForServiceInstanceDeleteTimeout = 3600
+
+var (
+	ServiceInstanceContainerPath = "/paas/service/dbcs/api/v1.1/instances/%s"
+	ServiceInstanceResourcePath  = "/paas/service/dbcs/api/v1.1/instances/%s/%s"
+)
+
+// ServiceInstanceClient is a client for the Service functions of the Database API.
+type ServiceInstanceClient struct {
+	ResourceClient
+}
+
+// ServiceInstanceClient obtains an ServiceInstanceClient which can be used to access to the
+// Service Instance functions of the Database Cloud API
+func (c *DatabaseClient) ServiceInstanceClient() *ServiceInstanceClient {
+	return &ServiceInstanceClient{
+		ResourceClient: ResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    ServiceInstanceContainerPath,
+			ResourceRootPath: ServiceInstanceResourcePath,
+		}}
+}
+
+type ServiceInstanceEdition string
+
+const (
+	// SE: Standard Edition
+	ServiceInstanceStandardEdition ServiceInstanceEdition = "SE"
+	// EE: Enterprise Edition
+	ServiceInstanceEnterpriseEdition ServiceInstanceEdition = "EE"
+	// EE_HP: Enterprise Edition - High Performance
+	ServiceInstanceEnterpriseEditionHighPerformance ServiceInstanceEdition = "EE_HP"
+	// EE_EP: Enterprise Edition - Extreme Performance
+	ServiceInstanceEnterpriseEditionExtremePerformance ServiceInstanceEdition = "EE_EP"
+)
+
+type ServiceInstanceLevel string
+
+const (
+	// PAAS: The Oracle Database Cloud Service service level
+	ServiceInstanceLevelPAAS ServiceInstanceLevel = "PAAS"
+	// BASIC: The Oracle Database Cloud Service - Virtual Image service level
+	ServiceInstanceLevelBasic ServiceInstanceLevel = "BASIC"
+)
+
+type ServiceInstanceBool string
+
+const (
+	ServiceInstanceYes ServiceInstanceBool = "yes"
+	ServiceInstanceNo  ServiceInstanceBool = "no"
+)
+
+type ServiceInstanceBackupDestination string
+
+const (
+	// BOTH - Both Cloud Storage and Local Storage
+	ServiceInstanceBackupDestinationBoth ServiceInstanceBackupDestination = "BOTH"
+	// OSS - Cloud Storage only
+	ServiceInstanceBackupDestinationOSS ServiceInstanceBackupDestination = "OSS"
+	// NONE - None
+	ServiceInstanceBackupDestinationNone ServiceInstanceBackupDestination = "NONE"
+)
+
+type ServiceInstanceNCharSet string
+
+const (
+	ServiceInstanceNCharSetUTF16 ServiceInstanceNCharSet = "AL16UTF16"
+	ServiceInstanceNCharSetUTF8  ServiceInstanceNCharSet = "UTF8"
+)
+
+type ServiceInstanceType string
+
+const (
+	ServiceInstanceTypeDB ServiceInstanceType = "db"
+)
+
+type ServiceInstanceShape string
+
+const (
+	// oc3: 1 OCPU, 7.5 GB memory
+	ServiceInstanceShapeOC3 ServiceInstanceShape = "oc3"
+	// oc4: 2 OCPUs, 15 GB memory
+	ServiceInstanceShapeOC4 ServiceInstanceShape = "oc4"
+	// oc5: 4 OCPUs, 30 GB memory
+	ServiceInstanceShapeOC5 ServiceInstanceShape = "oc5"
+	// oc6: 8 OCPUs, 15 GB memory
+	ServiceInstanceShapeOC6 ServiceInstanceShape = "oc6"
+	// oc1m: 1 OCPU, 15 GB memory
+	ServiceInstanceShapeOC1M ServiceInstanceShape = "oc1m"
+	// oc2m: 2 OCPUs, 30 GB memory
+	ServiceInstanceShapeOC2M ServiceInstanceShape = "oc2m"
+	// oc3m: 4 OCPUs, 60 GB memory
+	ServiceInstanceShapeOC3M ServiceInstanceShape = "oc3m"
+	// oc4m: 8 OCPUs, 120 GB memory
+	ServiceInstanceShapeOC4M ServiceInstanceShape = "oc4m"
+)
+
+type ServiceInstanceSubscriptionType string
+
+const (
+	ServiceInstanceSubscriptionTypeHourly  ServiceInstanceSubscriptionType = "HOURLY"
+	ServiceInstanceSubscriptionTypeMonthly ServiceInstanceSubscriptionType = "MONTHLY"
+)
+
+type ServiceInstanceVersion string
+
+const (
+	// 12.2.0.1
+	ServiceInstanceVersion12201 ServiceInstanceVersion = "12.2.0.1"
+	// 12.1.0.2
+	ServieInstanceVersion12102 ServiceInstanceVersion = "12.1.0.2"
+	// 11.2.0.4
+	ServiceInstanceVersion11204 ServiceInstanceVersion = "11.2.0.4"
+)
+
+type ServiceInstanceState string
+
+const (
+	// 	Configured: the service instance has been configured.
+	ServiceInstanceConfigured ServiceInstanceState = "Configured"
+	//	In Progress: the service instance is being created.
+	ServiceInstanceInProgress ServiceInstanceState = "In Progress"
+	//	Maintenance: the service instance is being stopped, started, restarted or scaled.
+	ServiceInstanceMaintenance ServiceInstanceState = "Maintenance"
+	//	Running: the service instance is running.
+	ServiceInstanceRunning ServiceInstanceState = "Running"
+	//	Stopped: the service instance is stopped.
+	ServiceInstanceStopped ServiceInstanceState = "Stopped"
+	//	Terminating: the service instance is being deleted.
+	ServiceInstanceTerminating ServiceInstanceState = "Terminating"
+)
+
+type ServiceInstance struct {
+	// The URL to use to connect to Oracle Application Express on the service instance.
+	ApexURL string `json:"apex_url"`
+	// The backup configuration of the service instance.
+	BackupDestination string `json:"backup_destination"`
+	// The version of cloud tooling for backup and recovery supported by the service instance.
+	BackupSupportedVersion string `backup_supported_version`
+	// The database character set of the database.
+	CharSet string `json:"charset"`
+	// The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
+	ConnectorDescriptorWithPublicIP string `json:"connect_descriptor_with_public_ip"`
+	// The user name of the Oracle Cloud user who created the service instance.
+	CreateBy string `json:"created_by"`
+	// The job id of the job that created the service instance.
+	CreationJobID string `json:"creation_job_id"`
+	// The date-and-time stamp when the service instance was created.
+	CreationTime string `json:"creation_time"`
+	// The Oracle Database version on the service instance, including the patch level.
+	CurrentVersion string `json:"current_version"`
+	// The URL to use to connect to Oracle DBaaS Monitor on the service instance.
+	DBAASMonitorURL string `json:"dbaasmonitor_url"`
+	// The description of the service instance, if one was provided when the instance was created.
+	Description string `json:"description"`
+	// The software edition of the service instance.
+	Edition ServiceInstanceEdition `json:"edition"`
+	// The URL to use to connect to Enterprise Manager on the service instance.
+	EMURL string `json:"em_url"`
+	// Indicates whether the service instance hosts an Oracle Data Guard configuration.
+	FailoverDatabase bool `json:"failover_database"`
+	// The URL to use to connect to the Oracle GlassFish Server Administration Console on the service instance.
+	GlassFishURL string `json:"glassfish_url"`
+	// The identity domain housing the service instance.
+	IdentityDomain string `json:"identity_domain"`
+	// The Oracle Java Cloud Service instances using this Database Cloud Service instance.
+	JAASInstancesUsingService string `json:"jaas_instances_using_service"`
+	// The date-and-time stamp when the service instance was last modified.
+	LastModifiedTime string `json:"last_modified_time"`
+	// The service level of the service instance.
+	Level ServiceInstanceLevel `json:"level"`
+	// The listener port for Oracle Net Services (SQL*Net) connections.
+	ListenerPort int `json:"listener_port"`
+	// The national character set of the database.
+	NCharSet string `json:"ncharset"`
+	// The number of Oracle Compute Service IP reservations assigned to the service instance.
+	NumIPReservations int `json:"num_ip_reservations"`
+	// The number of compute nodes in the service instance.
+	NumNodes string `json:"num_nodes"`
+	// The name of the default PDB (pluggable database) created when the service instance was created.
+	PDBName string `json:"pdbName"`
+	// Indicates whether the service instance hosts an Oracle RAC database.
+	RACDatabase bool `json:"rac_database"`
+	// The name of the service instance.
+	Name string `json:"service_name"`
+	// The REST endpoint URI of the service instance.
+	URI string `json:"service_uri"`
+	// The Oracle Compute Cloud shape of the service instance.
+	Shape string `json:"shape"`
+	// The SID of the database.
+	SID string `json:"sid"`
+	// The version of the cloud tooling service manager plugin supported by the service instance.
+	SMPluginVersion string `json:"sm_plugin_version"`
+	// The status of the service instance
+	Status ServiceInstanceState `json:"status"`
+	// The billing frequency of the service instance; either MONTHLY or HOURLY.
+	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
+	// The time zone of the operating system.
+	Timezone string `json:"timezone"`
+	// For service instances hosting an Oracle RAC database, the size in GB of the storage shared
+	// and accessed by the nodes of the RAC database.
+	TotalSharedStorage int `json:"total_shared_storage"`
+	// The Oracle Database version on the service instance.
+	Version string `json:"version"`
+}
+
+type CreateServiceInstanceInput struct {
+	// Free-form text that provides additional information about the service instance.
+	// Optional.
+	Description string `json:"description,omitempty"`
+	// Database edition for the service instance:
+	// If you specify SE, a Standard Edition 2 database is created if you specify 12.2.0.1 or 12.1.0.2
+	// for version and a Standard Edition One database is created if you specify 11.2.0.4 for version.
+	// Edition must be Enterprise Edition - Extreme Performance to configure the Database
+	// Cloud Service instance as Cluster Database.
+	// Required.
+	Edition ServiceInstanceEdition `json:"edition"`
+	// Service level for the service instance
+	// Required.
+	Level ServiceInstanceLevel `json:"level"`
+	// Array of one JSON object that specifies configuration details of the services instance.
+	// This array is not required if the level value is BASIC.
+	// Required if level value is PAAS.
+	Parameters []Parameter `json:"parameters,omitempty"`
+	// Name of Database Cloud Service instance. The service name:
+	// Must not exceed 50 characters.
+	// Must start with a letter.
+	// Must contain only letters, numbers, or hyphens.
+	// Must not contain any other special characters.
+	// Must be unique within the identity domain.
+	// Required.
+	Name string `json:"serviceName"`
+	// Desired compute shape. A shape defines the number of Oracle Compute Units (OCPUs) and amount
+	// of memory (RAM).
+	// Required.
+	Shape ServiceInstanceShape `json:"shape"`
+	// Billing unit. Valid values are:
+	// HOURLY: Pay only for the number of hours used during your billing period. This is the default.
+	// MONTHLY: Pay one price for the full month irrespective of the number of hours used.
+	// Required.
+	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
+	// Oracle Database software version
+	// Required.
+	Version ServiceInstanceVersion `json:"version"`
+	// Public key for the secure shell (SSH). This key will be used for authentication when
+	// connecting to the Database Cloud Service instance using an SSH client. You generate an
+	// SSH public-private key pair using a standard SSH key generation tool. See Connecting to
+	// a Compute Node Through Secure Shell (SSH) in Using Oracle Database Cloud Service.
+	// Required.
+	VMPublicKey string `json:"vmPublicKeyText"`
+}
+
+type Parameter struct {
+	AdditonalParameters AdditionalParameters `json:"additionalParams,omitempty"`
+	// Password for Oracle Database administrator users sys and system. The password must meet the following requirements:
+	// Starts with a letter
+	// Is between 8 and 30 characters long
+	// Contains letters, at least one number, and optionally, any number of these special characters: dollar sign ($), pound sign (#), and underscore (_).
+	// Required
+	AdminPassword string `json:"adminPassword"`
+	//Backup destination.
+	// Required
+	BackupDestination ServiceInstanceBackupDestination `json:"backupDestination"`
+	// Character Set for the Database Cloud Service Instance.
+	// Valid values are AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS,
+	// AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721,
+	// AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13,
+	// BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111,
+	// CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS,
+	// EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851,
+	// EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS,
+	// IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSC5601,
+	// KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117,
+	// LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866,
+	// SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII,
+	// US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P1, WE8ISO8859P15, WE8ISO8859P9,
+	// WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8,
+	// ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC,
+	// ZHT32SOPS, ZHT32TRIS.
+	// Default value is AL32UTF8.
+	// Optional.
+	CharSet string `json:"charset,omitempty"`
+	// Name of the Oracle Storage Cloud Service container used to provide storage for your service
+	// instance backups. Use the following format to specify the container name:
+	// <storageservicename>-<storageidentitydomain>/<containername>
+	// Notes:
+	// An Oracle Storage Cloud Service container is not required when provisioning a Database
+	// Cloud Service - Virtual Image instance.
+	// Do not use an Oracle Storage Cloud container that you use to back up Database Cloud Service
+	// instances for any other purpose. For example, do not also use it to back up Oracle Java Cloud
+	// Service instances. Using the container for multiple purposes can result in billing errors.
+	// Optional.
+	CloudStorageContainer string `json:"cloudStorageContainer,omitempty"`
+	// Password for the Oracle Storage Cloud Service administrator.
+	// Optional.
+	CloudStoragePassword string `json:"cloudStoragePwd,omitempty"`
+	// Username for the Oracle Storage Cloud Service administrator.
+	// Optional.
+	CloudStorageUsername string `json:"cloudStorageUser,omitempty"`
+	// Specify if the given cloudStorageContainer is to be created if it does not already exist.
+	// Default value is false.
+	// Optional.
+	CreateStorageContainerIfMissing bool `json:"createStorageContainerIfMissing,omitempty"`
+	// Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option
+	// or the High Availability option. Valid values are yes and no:
+	// yes - The Disaster Recovery option is used, which places the compute node hosting the primary
+	// database and the compute node hosting the standby database in compute zones of different data centers.
+	// no - The High Availability option is used, which places the compute node hosting the primary
+	// database and the compute node hosting the standby database in different compute zones of the same
+	// data center.
+	// Default value is no.
+	// This option is applicable only when failoverDatabase is set to yes.
+	// Optional
+	DisasterRecovery ServiceInstanceBool `json:"disasterRecovery,omitempty"`
+	// Specify if an Oracle Data Guard configuration comprising a primary database and a
+	// standby database is created. Valid values are yes and no. Default value is no.
+	// You cannot set both failoverDatabase and isRac to yes.
+	// Optional
+	FailoverDatabase ServiceInstanceBool `json:"failoverDatabase,omitempty"`
+	// Specify if the database should be configured for use as the replication database of an
+	// Oracle GoldenGate Cloud Service instance. Valid values are yes and no. Default value is no.
+	// You cannot set goldenGate to yes if either isRac or failoverDatabase is set to yes.
+	// Optional
+	GoldenGate ServiceInstanceBool `json:"goldenGate,omitempty"`
+	// Specify if the service instance's database should, after the instance is created, be replaced
+	// by a database stored in an existing cloud backup that was created using Oracle Database Backup
+	// Cloud Service. Valid values are yes and no. Default value is no.
+	// Optional
+	IBKUP ServiceInstanceBool `json:"ibkup,omitempty"`
+	// Name of the Oracle Storage Cloud Service container where the existing cloud backup is stored.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPCloudStoragePassword string `json:"ibkupCloudStoragePassword,omitempty"`
+	// User name of an Oracle Cloud user who has read access to the container specified in
+	// ibkupCloudStorageContainer.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPCloudStorageUser string `json:"ibkupCloudStorageUser,omitempty"`
+	// Database id of the database from which the existing cloud backup was created.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPDatabaseID string `json:"ibkupDatabaseID,omitempty"`
+	// Password used to create the existing, password-encrypted cloud backup.
+	// This password is used to decrypt the backup.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPDecryptionKey string `json:"ibkupDecryptionKey,omitempty"`
+	// String containing the xsd:base64Binary representation of the cloud backup's wallet archive file.
+	// Optional
+	IBKUPWalletFileContent string `json:"ibkupWalletFileContent,omitempty"`
+	// Specify if a cluster database using Oracle Real Application Clusters should be configured.
+	// Valid values are yes and no. Default value is no.
+	// Optional
+	IsRAC ServiceInstanceBool `json:"isRac,omitempty"`
+	// National Character Set for the Database Cloud Service instance.
+	// Default value is AL16UTF16.
+	// Optional.
+	NCharSet ServiceInstanceNCharSet `json:"ncharset,omitempty"`
+	// Note: This attribute is valid when Database Cloud Service instance is configured with version 12c.
+	// Pluggable Database Name for the Database Cloud Service instance.
+	// Default value is pdb1.
+	// Optional.
+	PDBName string `json:"pdbName,omitempty"`
+	// Database Name (sid) for the Database Cloud Service instance.
+	// Default value is ORCL.
+	// Required.
+	SID string `json:"sid"`
+	// The name of the snapshot of the service instance specified by sourceServiceName
+	// that is to be used to create a "snapshot clone".
+	// This parameter is valid only if sourceServiceName is specified.
+	// Optional.
+	SnapshotName string `json:"snapshotName,omitempty"`
+	// When present, indicates that the service instance should be created as a
+	// "snapshot clone" of another service instance. Provide the name of the existing service
+	// instance whose snapshot is to be used.
+	// Optional.
+	SourceServiceName string `json:"sourceServiceName,omitempty"`
+	// Time Zone for the Database Cloud Service instance.
+	// Valid values are Africa/Cairo, Africa/Casablanca, Africa/Harare, Africa/Monrovia,
+	// Africa/Nairobi, Africa/Tripoli, Africa/Windhoek, America/Araguaina, America/Asuncion,
+	// America/Bogota, America/Caracas, America/Chihuahua, America/Cuiaba, America/Denver,
+	// America/Fortaleza, America/Guatemala, America/Halifax, America/Manaus, America/Matamoros,
+	// America/Monterrey, America/Montevideo, America/Phoenix, America/Santiago, America/Tijuana,
+	// Asia/Amman, Asia/Ashgabat, Asia/Baghdad, Asia/Baku, Asia/Bangkok, Asia/Beirut, Asia/Calcutta,
+	// Asia/Damascus, Asia/Dhaka, Asia/Irkutsk, Asia/Jerusalem, Asia/Kabul, Asia/Karachi,
+	// Asia/Kathmandu, Asia/Krasnoyarsk, Asia/Magadan, Asia/Muscat, Asia/Novosibirsk, Asia/Riyadh,
+	// Asia/Seoul, Asia/Shanghai, Asia/Singapore, Asia/Taipei, Asia/Tehran, Asia/Tokyo, Asia/Ulaanbaatar,
+	// Asia/Vladivostok, Asia/Yakutsk, Asia/Yerevan, Atlantic/Azores, Australia/Adelaide,
+	// Australia/Brisbane, Australia/Darwin, Australia/Hobart, Australia/Perth, Australia/Sydney,
+	// Brazil/East, Canada/Newfoundland, Canada/Saskatchewan, Europe/Amsterdam, Europe/Athens,
+	// Europe/Dublin, Europe/Helsinki, Europe/Istanbul, Europe/Kaliningrad, Europe/Moscow,
+	// Europe/Paris, Europe/Prague, Europe/Sarajevo, Pacific/Auckland, Pacific/Fiji, Pacific/Guam,
+	// Pacific/Honolulu, Pacific/Samoa, US/Alaska, US/Central, US/Eastern, US/East-Indiana,
+	// US/Pacific, UTC.
+	// Default value is UTC.
+	// Optional.
+	Timezone string `json:"timezone,omitempty"`
+	// Component type to which the set of parameters applies.
+	// Valid values are: db - Oracle Database
+	// Required.
+	Type ServiceInstanceType `json:"type"`
+	// Storage size for data (in GB). Minimum value is 15. Maximum value depends on the backup
+	// destination: if BOTH is specified, the maximum value is 1200; if OSS or NONE is specified,
+	// the maximum value is 2048.
+	// Required.
+	UsableStorage string `json:"usableStorage"`
+}
+
+type AdditionalParameters struct {
+	// Indicates whether to include the Demos PDB
+	// Optional
+	DBDemo ServiceInstanceBool `json:"db_demo,omitempty"`
+}
+
+// CreateServiceInstance creates a new ServiceInstace.
+func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstanceInput) (*ServiceInstance, error) {
+	var (
+		serviceInstance      *ServiceInstance
+		serviceInstanceError error
+	)
+	// return nil, fmt.Errorf("%+v", input)
+	for i := 0; i < *c.DatabaseClient.client.MaxRetries; i++ {
+		c.client.DebugLogString(fmt.Sprintf("(Iteration: %d of %d) Creating service instance with name %s\n Input: %+v", i, *c.DatabaseClient.client.MaxRetries, input.Name, input))
+
+		serviceInstance, serviceInstanceError = c.startServiceInstance(input.Name, input)
+		if serviceInstanceError == nil {
+			c.client.DebugLogString(fmt.Sprintf("(Iteration: %d of %d) Finished creating service instance with name %s\n Info: %+v", i, *c.DatabaseClient.client.MaxRetries, input.Name, serviceInstance))
+			return serviceInstance, nil
+		}
+	}
+	return nil, serviceInstanceError
+}
+
+func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateServiceInstanceInput) (*ServiceInstance, error) {
+	if err := c.createResource(*input, nil); err != nil {
+		return nil, err
+	}
+
+	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: name,
+	}
+
+	// Wait for the service instance to be running and return the result
+	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
+	serviceInstance, serviceInstanceError := c.WaitForServiceInstanceRunning(getInput, WaitForServiceInstanceReadyTimeout)
+	// If the service instance enters an error state we need to delete the instance and retry
+	if serviceInstanceError != nil {
+		deleteInput := &DeleteServiceInstanceInput{
+			Name: name,
+		}
+		err := c.DeleteServiceInstance(deleteInput)
+		if err != nil {
+			return nil, fmt.Errorf("Error deleting service instance %s: %s", name, err)
+		}
+		return nil, serviceInstanceError
+	}
+	return serviceInstance, nil
+}
+
+// WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.
+func (c *ServiceInstanceClient) WaitForServiceInstanceRunning(input *GetServiceInstanceInput, timeoutSeconds int) (*ServiceInstance, error) {
+	var info *ServiceInstance
+	var getErr error
+	err := c.client.WaitFor("service instance to be ready", timeoutSeconds, func() (bool, error) {
+		info, getErr = c.GetServiceInstance(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("Service instance name is %v, Service instance info is %+v", info.Name, info))
+		switch s := info.Status; s {
+		case ServiceInstanceRunning: // Target State
+			c.client.DebugLogString("Service Instance Running")
+			return false, nil
+		case ServiceInstanceConfigured:
+			c.client.DebugLogString("Service Instance Configured")
+			return true, nil
+		case ServiceInstanceInProgress:
+			c.client.DebugLogString("Service Instance is being created")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown instance state: %s, waiting", s))
+			return false, nil
+		}
+	})
+	return info, err
+}
+
+type GetServiceInstanceInput struct {
+	// Name of the Database Cloud Service instance.
+	// Required.
+	Name string `json:"serviceId"`
+}
+
+// GetServiceInstance retrieves the SeriveInstance with the given name.
+func (c *ServiceInstanceClient) GetServiceInstance(getInput *GetServiceInstanceInput) (*ServiceInstance, error) {
+	var serviceInstance ServiceInstance
+	if err := c.getResource(getInput.Name, &serviceInstance); err != nil {
+		return nil, err
+	}
+
+	return &serviceInstance, nil
+}
+
+type DeleteServiceInstanceInput struct {
+	// Name of the Database Cloud Service instance.
+	// Required.
+	Name string `json:"serviceId"`
+}
+
+func (c *ServiceInstanceClient) DeleteServiceInstance(deleteInput *DeleteServiceInstanceInput) error {
+	// Call to delete the service instance
+	// If delete fails, rerun it in case the instance still has not been setup correctly.
+	// An instance takes additional time to setup after it's configured.
+	var deleteErr error
+	for i := 0; i < 5; i++ {
+		if deleteErr = c.deleteResource(deleteInput.Name); deleteErr != nil {
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		break
+	}
+	if deleteErr != nil {
+		return deleteErr
+	}
+
+	// Call wait for instance deleted now, as deleting the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: deleteInput.Name,
+	}
+
+	// Wait for instance to be deleted
+	return c.WaitForServiceInstanceDeleted(getInput, WaitForServiceInstanceDeleteTimeout)
+}
+
+// WaitForServiceInstanceDeleted waits for a service instance to be fully deleted.
+func (c *ServiceInstanceClient) WaitForServiceInstanceDeleted(input *GetServiceInstanceInput, timeoutSeconds int) error {
+	return c.client.WaitFor("service instance to be deleted", timeoutSeconds, func() (bool, error) {
+		info, err := c.GetServiceInstance(input)
+		if err != nil {
+			if client.WasNotFoundError(err) {
+				// Service Instance could not be found, thus deleted
+				return true, nil
+			}
+			// Some other error occurred trying to get instance, exit
+			return false, err
+		}
+		switch s := info.Status; s {
+		case ServiceInstanceTerminating:
+			c.client.DebugLogString("Service Instance terminating")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown instance state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_ServiceInstanceName              = "testing-db-service-instance"
+	_ServiceInstanceEdition           = "EE_EP"
+	_ServiceInstanceLevel             = "PAAS"
+	_ServiceInstanceShape             = "oc1m"
+	_ServiceInstanceSubscription      = "HOURLY"
+	_ServiceInstanceVersion           = "12.2.0.1"
+	_ServiceInstancePubKey            = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+	_ServiceInstancePassword          = "Test_String7"
+	_ServiceInstanceBackupDestination = "NONE"
+	_ServiceInstanceDBSID             = "ORCL"
+	_ServiceInstanceType              = "db"
+	_ServiceInstanceUsableStorage     = "15"
+)
+
+func TestAccServiceInstanceLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	siClient, err := getServiceInstanceTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parameter := &Parameter{
+		AdminPassword:     _ServiceInstancePassword,
+		BackupDestination: _ServiceInstanceBackupDestination,
+		SID:               _ServiceInstanceDBSID,
+		Type:              _ServiceInstanceType,
+		UsableStorage:     _ServiceInstanceUsableStorage,
+	}
+
+	createServiceInstance := &CreateServiceInstanceInput{
+		Name:             _ServiceInstanceName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscription,
+		Version:          _ServiceInstanceVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameters:       []Parameter{*parameter},
+	}
+
+	_, err = siClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer destroyServiceInstance(t, siClient, _ServiceInstanceName)
+
+	getInput := &GetServiceInstanceInput{
+		Name: _ServiceInstanceName,
+	}
+
+	receivedRes, err := siClient.GetServiceInstance(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.Name != _ServiceInstanceName {
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", _ServiceInstanceName, receivedRes.Name))
+	}
+}
+
+func getServiceInstanceTestClients() (*ServiceInstanceClient, error) {
+	client, err := getDatabaseTestClient(&opc.Config{})
+	if err != nil {
+		return &ServiceInstanceClient{}, err
+	}
+
+	return client.ServiceInstanceClient(), nil
+}
+
+func destroyServiceInstance(t *testing.T, client *ServiceInstanceClient, name string) {
+	input := &DeleteServiceInstanceInput{
+		Name: name,
+	}
+
+	if err := client.DeleteServiceInstance(input); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/database/test_utils.go
+++ b/database/test_utils.go
@@ -1,0 +1,47 @@
+package database
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+func getDatabaseTestClient(c *opc.Config) (*DatabaseClient, error) {
+	// Build up config with default values if omitted
+
+	if c.IdentityDomain == nil {
+		domain := os.Getenv("OPC_IDENTITY_DOMAIN")
+		c.IdentityDomain = &domain
+	}
+
+	if c.Username == nil {
+		username := os.Getenv("OPC_USERNAME")
+		c.Username = &username
+	}
+
+	if c.Password == nil {
+		password := os.Getenv("OPC_PASSWORD")
+		c.Password = &password
+	}
+
+	if c.APIEndpoint == nil {
+		apiEndpoint, err := url.Parse(os.Getenv("OPC_DATABASE_ENDPOINT"))
+		if err != nil {
+			return nil, err
+		}
+		c.APIEndpoint = apiEndpoint
+	}
+
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				TLSHandshakeTimeout: 120 * time.Second},
+		}
+	}
+
+	return NewDatabaseClient(c)
+}


### PR DESCRIPTION
This PR adds the [Oracle Database Service Instance](http://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/api-Service%20Instances.html). Our testing account only allows us to test the `PAAS` level and not the `BASIC` level. 

```
make testacc TEST=./database TESTARGS="-run=TestAccServiceInstanceLifeCycle"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccServiceInstanceLifeCycle -timeout 120m
=== RUN   TestAccServiceInstanceLifeCycle
--- PASS: TestAccServiceInstanceLifeCycle (1724.32s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/database	1724.347s
```