### PR TITLE
storage_object: Add `id` helper attribute

### DIFF
--- a/storage/object.go
+++ b/storage/object.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 type ObjectClient struct {
@@ -47,10 +48,12 @@ const (
 	h_TransferEncoding   = "Transfer-Encoding"
 )
 
-// Object Info describes an existing object
+// ObjectInfo describes an existing object
 // Optional values may not be passed in as response headers
 // TODO: Add query parameters if needed
 type ObjectInfo struct {
+	// ID is the container name + "/" object name for convenience
+	ID string
 	// Name of the object
 	Name string
 	// Type of ranges the object accepts
@@ -88,7 +91,7 @@ type ObjectInfo struct {
 	TransactionID string
 }
 
-// Input struct for a Create Method to create a storage object
+// CreateObjectInput struct for a Create Method to create a storage object
 // TODO: Add query parameters if needed
 type CreateObjectInput struct {
 	// Name of the object.
@@ -174,17 +177,21 @@ func (c *ObjectClient) CreateObject(input *CreateObjectInput) (*ObjectInfo, erro
 	return c.GetObject(getInput)
 }
 
-// Get details on a storage object
+// GetObjectInput details on a storage object
 // TODO: Add query parameters if needed
 type GetObjectInput struct {
 	// TODO If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
 	// If we actually want to support these
 
+	// ID of the object (container/object)
+	// Optional - Either ID or Name + Container are required
+	ID string
+
 	// Name of the object to get details on
-	// Required
+	// Optional - Either ID or Name + Container are required
 	Name string
 	// Name of the container
-	// Required
+	// Optional - Either ID or Name + Container are required
 	Container string
 	// Range of data to receive. Must be specified via a byte range:
 	// bytes=-5; bytes=10-15. Accept the entire string here, as multiple ranges
@@ -199,12 +206,20 @@ type GetObjectInput struct {
 	Newest bool
 }
 
-// Accepts a input struct, returns an info struct
+// GetObject accepts a input struct, returns an info struct
 func (c *ObjectClient) GetObject(input *GetObjectInput) (*ObjectInfo, error) {
 	var object ObjectInfo
 	headers := make(map[string]string)
 
-	name := c.getQualifiedName(fmt.Sprintf("%s/%s", input.Container, input.Name))
+	var name string
+	if input.ID != "" {
+		name = c.getQualifiedName(input.ID)
+	} else {
+		if input.Container == "" && input.Name == "" {
+			return nil, fmt.Errorf("Either ID or Name and Container must be set during READ")
+		}
+		name = c.getQualifiedName(fmt.Sprintf("%s/%s", input.Container, input.Name))
+	}
 
 	// Build request headers
 	headers[h_Range] = input.Range
@@ -215,26 +230,51 @@ func (c *ObjectClient) GetObject(input *GetObjectInput) (*ObjectInfo, error) {
 		return nil, err
 	}
 
-	// Set Name and container, not returned from API
-	object.Name = input.Name
-	object.Container = input.Container
+	// Set Name, container, and ID. Not returned from API
+	if input.ID != "" {
+		parts := strings.Split(input.ID, "/")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("Unknown ID specified: %s", input.ID)
+		}
+		object.ID = input.ID
+		object.Container = parts[0]
+		object.Name = parts[1]
+	} else {
+		// Already checked for Nil container and name above
+		object.ID = fmt.Sprintf("%s/%s", input.Container, input.Name)
+		object.Name = input.Name
+		object.Container = input.Container
+	}
 
 	return c.success(resp, &object)
 }
 
-// Input struct for deleting objects
+// DeleteObjectInput struct for deleting objects
 // TODO: Add query parameters if needed
 type DeleteObjectInput struct {
+	// ID is the container name + "/" + object name
+	// Optional - Either ID or Name + Container are required
+	ID string
 	// Name of the Object to delete
-	// Required
+	// Optional - Either ID or Name + Container are required
 	Name string
 	// Name of the container
-	// Required
+	// Optional - Either ID or Name + Container are required
 	Container string
 }
 
+// DeleteObject will delete the supplied object
 func (c *ObjectClient) DeleteObject(input *DeleteObjectInput) error {
-	name := fmt.Sprintf("%s/%s", input.Container, input.Name)
+	var name string
+	if input.ID != "" {
+		name = input.ID
+	} else {
+		if input.Container == "" && input.Name == "" {
+			return fmt.Errorf("Either ID or Name and Container must be set during DELETE")
+		}
+		name = fmt.Sprintf("%s/%s", input.Container, input.Name)
+	}
+
 	return c.deleteResource(c.getQualifiedName(name))
 }
 

--- a/storage/object_test.go
+++ b/storage/object_test.go
@@ -14,8 +14,9 @@ import (
 
 const (
 	_TestObjectName          = "testing-acc-object"
-	_TestFileFixturesPath    = "./test-fixtures"
+	_TestFileFixturesPath    = "test-fixtures"
 	_TestSourceContentLength = 2351
+	_TestFileContentLength   = 2350
 	_TestContentType         = "text/plain;charset=UTF-8"
 	_TestAcceptRanges        = "bytes"
 )
@@ -62,6 +63,7 @@ func TestAccObjectLifeCycle_contentSource(t *testing.T) {
 		ContentLength:      _TestSourceContentLength,
 		ContentType:        _TestContentType,
 		DeleteAt:           0,
+		ID:                 fmt.Sprintf("%s/%s", _ContainerName, _TestObjectName),
 		ObjectManifest:     "",
 	}
 
@@ -87,7 +89,11 @@ func TestAccObjectLifeCycle_fileSource(t *testing.T) {
 	log.Printf("[DEBUG] Container created: %+v", container)
 
 	// Create body seeker
-	body, err := os.Open(_TestFileFixturesPath + "input.txt")
+	body, err := os.Open(_TestFileFixturesPath + "/input.txt")
+	if err != nil {
+		t.Fatalf("Error reading file: %v", err)
+	}
+
 	input := &CreateObjectInput{
 		Name:        _TestObjectName,
 		Container:   container.Name,
@@ -109,9 +115,10 @@ func TestAccObjectLifeCycle_fileSource(t *testing.T) {
 		Container:          _ContainerName,
 		ContentDisposition: "",
 		ContentEncoding:    "",
-		ContentLength:      _TestSourceContentLength,
+		ContentLength:      _TestFileContentLength,
 		ContentType:        _TestContentType,
 		DeleteAt:           0,
+		ID:                 fmt.Sprintf("%s/%s", _ContainerName, _TestObjectName),
 		ObjectManifest:     "",
 	}
 
@@ -223,7 +230,7 @@ func testAssertions(result, expected *ObjectInfo) error {
 	}
 	result.TransactionID = ""
 
-	if diff := pretty.Compare(expected, result); diff != "" {
+	if diff := pretty.Compare(result, expected); diff != "" {
 		return fmt.Errorf("Result Diff (-got +want)\n%s", diff)
 	}
 


### PR DESCRIPTION
Adds an `id` helper attribute to make the provider a little easier to
navigate, especially during an import.

```
$ make testacc TEST=./storage TESTARGS="-run=TestAccObjectLifeCycle_contentSourceID"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./storage -run=TestAccObjectLifeCycle_contentSourceID -timeout 120m
=== RUN   TestAccObjectLifeCycle_contentSourceID
--- PASS: TestAccObjectLifeCycle_contentSourceID (1.59s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/storage        1.590s
```