### PR TITLE
Added exposed headers and fixed allowed origins

### DIFF
--- a/storage/container.go
+++ b/storage/container.go
@@ -20,6 +20,8 @@ type Container struct {
 	SecondaryKey string
 	// List of origins to be allowed to make cross-origin Requests.
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	ExposedHeaders []string
 	// Maximum age in seconds for the origin to hold the preflight results.
 	MaxAge int
 }
@@ -47,6 +49,9 @@ type CreateContainerInput struct {
 	// Sets the list of origins allowed to make cross-origin requests.
 	// Optional
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	// Optional
+	ExposedHeaders []string
 	// Sets the maximum age in seconds for the origin to hold the preflight results.
 	// Optional
 	MaxAge int
@@ -68,7 +73,8 @@ func (c *StorageClient) CreateContainer(input *CreateContainerInput) (*Container
 
 	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
 	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
-	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Allow-Origin"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.ExposedHeaders, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
 
 	if err := c.createResource(input.Name, headers); err != nil {
@@ -136,6 +142,9 @@ type UpdateContainerInput struct {
 	// Updates the list of origins allowed to make cross-origin requests.
 	// Optional
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	// Optional
+	ExposedHeaders []string
 	// Updates the maximum age in seconds for the origin to hold the preflight results.
 	// Optional
 	MaxAge int
@@ -155,7 +164,8 @@ func (c *StorageClient) UpdateContainer(input *UpdateContainerInput) (*Container
 
 	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
 	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
-	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Allow-Origin"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.ExposedHeaders, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
 
 	input.Name = c.getQualifiedName(input.Name)
@@ -175,7 +185,8 @@ func (c *StorageClient) success(rsp *http.Response, container *Container) (*Cont
 	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
 	container.PrimaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
 	container.SecondaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
-	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
+	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Allow-Origin"), " ")
+	container.ExposedHeaders = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
 	container.MaxAge, err = strconv.Atoi(rsp.Header.Get("X-Container-Meta-Access-Control-Max-Age"))
 	if err != nil {
 		return nil, err

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -26,6 +26,7 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	readACLs := []string{"test-read-acl1", "test-read-acl2"}
 	writeACLs := []string{"test-write-acl1", "test-write-acl2"}
 	allowedOrigins := []string{"allowed-origin-1", "allowed-origin-2"}
+	exposedHeaders := []string{"exposed-header-1", "exposed-header-2"}
 
 	createContainerInput := CreateContainerInput{
 		Name:           _ContainerName,
@@ -34,6 +35,7 @@ func TestAccContainerLifeCycle(t *testing.T) {
 		PrimaryKey:     _ContainerPrimaryKey,
 		SecondaryKey:   _ContainerSecondaryKey,
 		AllowedOrigins: allowedOrigins,
+		ExposedHeaders: exposedHeaders,
 	}
 
 	createdContainer, err := client.CreateContainer(&createContainerInput)
@@ -65,18 +67,23 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	if diff := pretty.Compare(container.AllowedOrigins, allowedOrigins); diff != "" {
 		t.Fatalf(fmt.Sprintf("AllowedOrigin diff (-got +want)\n%s", diff))
 	}
+	if diff := pretty.Compare(container.ExposedHeaders, exposedHeaders); diff != "" {
+		t.Fatalf(fmt.Sprintf("ExposedHeader diff (-got +want)\n%s", diff))
+	}
 
 	log.Print("Successfully retrieved Container")
 
 	updateReadACLs := []string{"test-read-acl3", "test-read-acl4"}
 	updateWriteACLs := []string{"test-write-acl3", "test-write-acl4"}
 	updatedAllowedOrigins := []string{"allowed-origin-3", "allowed-origin-4"}
+	updatedExposedHeaders := []string{"exposed-header-3", "exposed-header-4"}
 	updateContainerInput := UpdateContainerInput{
 		Name:           _ContainerName,
 		ReadACLs:       updateReadACLs,
 		WriteACLs:      updateWriteACLs,
 		SecondaryKey:   _ContainerPrimaryKey,
 		AllowedOrigins: updatedAllowedOrigins,
+		ExposedHeaders: updatedExposedHeaders,
 		MaxAge:         _ContainerMaxAge,
 	}
 
@@ -107,6 +114,9 @@ func TestAccContainerLifeCycle(t *testing.T) {
 	}
 	if diff := pretty.Compare(container.AllowedOrigins, updatedAllowedOrigins); diff != "" {
 		t.Fatalf(fmt.Sprintf("Updated AllowedOrigin diff (-got +want)\n%s", diff))
+	}
+	if diff := pretty.Compare(container.ExposedHeaders, updatedExposedHeaders); diff != "" {
+		t.Fatalf(fmt.Sprintf("Updated Exposed Headers diff (-got +want)\n%s", diff))
 	}
 	if container.MaxAge != _ContainerMaxAge {
 		t.Fatalf(fmt.Sprintf("Max Age do not match Wanted: %s Recieved: %s", _ContainerMaxAge, container.MaxAge))


### PR DESCRIPTION
This PR fixes allowed origins and adds exposed headers. 

```
make testacc TEST=./storage TESTARGS="-run=TestAccContainerLifeCycle"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./storage -run=TestAccContainerLifeCycle -timeout 120m
=== RUN   TestAccContainerLifeCycle
--- PASS: TestAccContainerLifeCycle (2.13s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/storage	2.148s
```