### PR TITLE
database: Add utility resources

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -118,7 +118,7 @@ func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 	// Execute request with supplied client
 	resp, err := c.retryRequest(req)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
@@ -138,7 +138,10 @@ func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 		oracleErr.Message = buf.String()
 	}
 
-	return nil, oracleErr
+	// Should return the response object regardless of error,
+	// some resources need to verify and check status code on errors to
+	// determine if an error actually occurs or not.
+	return resp, oracleErr
 }
 
 // Allow retrying the request until it either returns no error,
@@ -158,7 +161,7 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 	for i := 0; i < retries; i++ {
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
 
 		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {

--- a/compute/compute_client.go
+++ b/compute/compute_client.go
@@ -38,7 +38,12 @@ func NewComputeClient(c *opc.Config) (*ComputeClient, error) {
 }
 
 func (c *ComputeClient) executeRequest(method, path string, body interface{}) (*http.Response, error) {
-	req, err := c.client.BuildRequest(method, path, body)
+	reqBody, err := c.client.MarshallRequestBody(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.client.BuildRequestBody(method, path, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +51,9 @@ func (c *ComputeClient) executeRequest(method, path string, body interface{}) (*
 	debugReqString := fmt.Sprintf("HTTP %s Req (%s)", method, path)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/oracle-compute-v3+json")
-		// Don't leak creds in STDERR
+		// Don't leak credentials in STDERR
 		if path != "/authenticate/" {
-			debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, body)
+			debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, string(reqBody))
 		}
 	}
 	// Log the request before the authentication cookie, so as not to leak credentials

--- a/database/access_rules.go
+++ b/database/access_rules.go
@@ -23,15 +23,6 @@ const (
 // Default Timeout value for Create
 const WaitForAccessRuleTimeout = time.Duration(10 * time.Second)
 
-// The UtilityClient which extends the UtilityResourceClient.
-// This is purely because utility resources (SSH Keys + Access Rules) include the service
-// instance name in the URL path for managing these resources, so we cannot use the same
-// resource client that the service instance uses. We're still using the same OPC client, just
-// abstracting the path helper functions to make life a little easier.
-type UtilityClient struct {
-	UtilityResourceClient
-}
-
 // AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a DBaaS Service Instance
 func (c *DatabaseClient) AccessRules() *UtilityClient {
 	return &UtilityClient{
@@ -216,7 +207,8 @@ type UpdateAccessRuleInput struct {
 
 // Updates an AccessRule with the provided input struct. Returns a fully populated Info struct
 // and any errors encountered
-func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput) (*AccessRuleInfo, error) {
+func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput,
+) (*AccessRuleInfo, error) {
 	if input.ServiceInstanceID != "" {
 		c.ServiceInstanceID = input.ServiceInstanceID
 	}

--- a/database/access_rules.go
+++ b/database/access_rules.go
@@ -62,6 +62,14 @@ type AccessRules struct {
 	Rules []AccessRuleInfo `json:"accessRules"`
 }
 
+type AccessRuleType string
+
+const (
+	AccessRuleTypeDefault AccessRuleType = "DEFAULT"
+	AccessRuleTypeSystem  AccessRuleType = "SYSTEM"
+	AccessRuleTypeUser    AccessRuleType = "USER"
+)
+
 // AccessRuleInfo holds all of the known information for a single AccessRule
 type AccessRuleInfo struct {
 	// The Description of the Access Rule
@@ -74,7 +82,7 @@ type AccessRuleInfo struct {
 	Name string `json:"ruleName"`
 	// The Type of the rule. One of: "DEFAULT", "SYSTEM", or "USER".
 	// Computed Value
-	RuleType string `json:"ruleType"`
+	RuleType AccessRuleType `json:"ruleType"`
 	// The IP Addresses and subnets from which traffic is allowed
 	Source string `json:"source"`
 	// The current status of the Access Rule

--- a/database/access_rules.go
+++ b/database/access_rules.go
@@ -1,0 +1,291 @@
+// Manages Access Rules for a DBaaS Service Instance.
+// The only fields that can be Updated for an Access Rule is the desired state
+// of the access rule. From Enabled -> Disabled.
+// Deleting an Access Rule also requires an Update call, instead of a Delete API request,
+// but the Operation body parameter changes from `update` to `delete`.
+// All other parameters for the resource, aside from Status should be ForceNew.
+// The READ function for the AccessRule resource is tricky, as there is
+// no exposed `GET` function on the AccessRule API.
+// There is an API endpoint to view "all" rules, however, which will be used as a
+// data source to match on a supplied AccessRule name.
+// Timeout only supported for the CREATE method
+
+package database
+
+import "time"
+
+// API URI Paths for Container and Root objects
+const (
+	DBAccessContainerPath = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/accessrules"
+	DBAccessRootPath      = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/accessrules/%s"
+)
+
+// Default Timeout value for Create
+const WaitForAccessRuleTimeout = time.Duration(10 * time.Second)
+
+// The UtilityClient which extends the UtilityResourceClient.
+// This is purely because utility resources (SSH Keys + Access Rules) include the service
+// instance name in the URL path for managing these resources, so we cannot use the same
+// resource client that the service instance uses. We're still using the same OPC client, just
+// abstracting the path helper functions to make life a little easier.
+type UtilityClient struct {
+	UtilityResourceClient
+}
+
+// AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a DBaaS Service Instance
+func (c *DatabaseClient) AccessRules() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    DBAccessContainerPath,
+			ResourceRootPath: DBAccessRootPath,
+		},
+	}
+}
+
+// Status Constants for an Access Rule
+type AccessRuleStatus string
+
+const (
+	AccessRuleEnabled  AccessRuleStatus = "enabled"
+	AccessRuleDisabled AccessRuleStatus = "disabled"
+)
+
+// Operational Constants for either Updating/Deleting an Access Rule
+type AccessRuleOperation string
+
+const (
+	AccessRuleUpdate AccessRuleOperation = "update"
+	AccessRuleDelete AccessRuleOperation = "delete"
+)
+
+// Default Destination for an Access Rule
+type AccessRuleDestination string
+
+const (
+	AccessRuleDefaultDestination AccessRuleDestination = "DB"
+)
+
+// Used for the GET request, as there's no direct GET request for a single Access Rule
+type AccessRules struct {
+	Rules []AccessRuleInfo `json:"accessRules"`
+}
+
+// AccessRuleInfo holds all of the known information for a single AccessRule
+type AccessRuleInfo struct {
+	// The Description of the Access Rule
+	Description string `json:"description"`
+	// The destination of the Access Rule. Should always be "DB".
+	Destination AccessRuleDestination `json:"destination"`
+	// The ports for the rule.
+	Ports string `json:"ports"`
+	// The name of the Access Rule
+	Name string `json:"ruleName"`
+	// The Type of the rule. One of: "DEFAULT", "SYSTEM", or "USER".
+	// Computed Value
+	RuleType string `json:"ruleType"`
+	// The IP Addresses and subnets from which traffic is allowed
+	Source string `json:"source"`
+	// The current status of the Access Rule
+	Status AccessRuleStatus `json:"status"`
+}
+
+// CreateAccessRuleInput defines the input parameters needed to create an Access Rule for a DBaaS Service Instance.
+type CreateAccessRuleInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Description of the Access Rule.
+	// Required
+	Description string `json:"description"`
+	// Destination to which traffic is allowed. Specify the value "DB".
+	// Required
+	Destination AccessRuleDestination `json:"destination"`
+	// The network port or ports to allow traffic on. Specified as a single port or a range.
+	// Required
+	Ports string `json:"ports"`
+	// The name of the Access Rule
+	// Required
+	Name string `json:"ruleName"`
+	// The IP addresses and subnets from which traffic is allowed.
+	// Valid values are:
+	//   - "DB" for any other cloud service instance in the service instances `ora_db` security list
+	//   - "PUBLIC-INTERNET" for any host on the internet.
+	//   - A single IP address or comma-separated list of subnets (in CIDR format) or IPv4 addresses.
+	// Required
+	Source string `json:"source"`
+	// Desired Status of the rule. Either "disabled" or "enabled".
+	// Required
+	Status AccessRuleStatus `json:"status"`
+	// Time to wait for an access rule to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Creates an AccessRule with the supplied input struct.
+// The API call to Create returns a nil body object, and a 202 status code on success.
+// Thus, the Create method will return the resulting object from an internal GET call
+// during the WaitForReady timeout.
+func (c *UtilityClient) CreateAccessRule(input *CreateAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRule AccessRuleInfo
+	if err := c.createResource(input, &accessRule); err != nil {
+		return nil, err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForAccessRuleTimeout
+	}
+
+	getInput := &GetAccessRuleInput{
+		Name: input.Name,
+	}
+
+	result, err := c.WaitForAccessRuleReady(getInput, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAccessRuleInput defines the input parameters needed to retrieve information
+// on an AccessRule for a DBaas Service Instance.
+type GetAccessRuleInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule.
+	// Because there is no native "GET" to return a single AccessRuleInfo object, we don't
+	// need to marshal a request body for the GET request. Instead the request returns a slice
+	// of AccessRuleInfo structs, which we iterate on to interpret the desired AccessRuleInfo struct
+	// Required
+	Name string `json:"-"`
+}
+
+// Get's a slice of every AccessRule, and iterates on the result until
+// we find the correctly matching access rule. This is likely an expensive operation depending
+// on how many access rules the customer has. However, since there's no direct GET API endpoint
+// for a single Access Rule, it's not able to be optimized yet.
+func (c *UtilityClient) GetAccessRule(input *GetAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRules AccessRules
+	if err := c.getResource("", &accessRules); err != nil {
+		return nil, err
+	}
+
+	// This is likely not the most optimal path for this, however, the upper bound on
+	// performance here is the actual API request, not the iteration.
+	for _, rule := range accessRules.Rules {
+		if rule.Name == input.Name {
+			return &rule, nil
+		}
+	}
+
+	// Iterated through entire slice, rule was not found.
+	// No error occured though, return a nil struct, and allow the Provdier to handle
+	// a Nil response case.
+	return nil, nil
+}
+
+// UpdateAccessRuleInput defines the Update parameters needed to update an AccessRule
+// for a DBaaS Service Instance.
+type UpdateAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Update function here, so the SDK uses the constant
+	// defined for Updating an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+}
+
+// Updates an AccessRule with the provided input struct. Returns a fully populated Info struct
+// and any errors encountered
+func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleUpdate
+	// Initialize the response struct
+	var accessRule AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &accessRule); err != nil {
+		return nil, err
+	}
+	return &accessRule, nil
+}
+
+// DeleteAccessRuleInput defines the Delete parameters needed to delete an AccessRule
+// for a DBaaS Service Instance. There's no dedicated DELETE method on the API, so this
+// mimics the same behavior of the Update method, but using the Delete operational constant.
+// Instead of implementing, choosing to be verbose here for ease of use in the Provider, and clarity.
+type DeleteAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Delete function here, so the SDK uses the constant
+	// defined for Deleting an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+}
+
+// Deletes an AccessRule with the provided input struct. Returns any errors that occurred.
+func (c *UtilityClient) DeleteAccessRule(input *DeleteAccessRuleInput) error {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleDelete
+	// The Update API call with a `DELETE` operation actually returns the same access rule info
+	// in a response body. As we are deleting the AccessRule, we don't actually need to parse that.
+	// However, the Update API call requires a pointer to parse, or else we throw an error during the
+	// json unmarshal
+	var result AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UtilityClient) WaitForAccessRuleReady(input *GetAccessRuleInput, timeout time.Duration) (*AccessRuleInfo, error) {
+	var info *AccessRuleInfo
+	var getErr error
+	err := c.client.WaitFor("access rule to be ready", timeout, func() (bool, error) {
+		info, getErr = c.GetAccessRule(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		if info != nil {
+			// Rule found, return. Desired case
+			return true, nil
+		}
+		// Rule not found, wait
+		return false, nil
+	})
+	return info, err
+}

--- a/database/access_rules_test.go
+++ b/database/access_rules_test.go
@@ -62,7 +62,7 @@ func TestAccAccessRulesLifeCycle(t *testing.T) {
 		Name:        _TestAccessRuleName,
 		Source:      _TestAccessRuleSource,
 		Status:      AccessRuleDisabled,
-		RuleType:    "USER",
+		RuleType:    AccessRuleTypeUser,
 	}
 
 	// Create Access Rule

--- a/database/access_rules_test.go
+++ b/database/access_rules_test.go
@@ -1,0 +1,156 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"os"
+
+	"log"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+// Testing Parameters Used
+const (
+	_TestAccessRuleDescription = "testing description"
+	_TestAccessRulePorts       = "7000-8000"
+	_TestAccessRuleSource      = "PUBLIC-INTERNET"
+)
+
+var _TestAccessRuleName = fmt.Sprintf("test-acc-rule-%d", helper.RInt())
+
+func TestAccAccessRulesLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	sClient, aClient, err := getAccessRulesTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var instanceName string
+	if v := os.Getenv("OPC_TEST_DB_INSTANCE"); v == "" {
+		// First Create a Service Instance
+		sInstance, err := sClient.createTestServiceInstance()
+		if err != nil {
+			t.Fatalf("Error creating Service Instance: %s", err)
+		}
+		defer destroyServiceInstance(t, sClient, sInstance.Name)
+		instanceName = sInstance.Name
+	} else {
+		log.Print("Using already created DB Service Instance")
+		instanceName = v
+	}
+
+	// Create an Access Rule that's disabled
+	input := &CreateAccessRuleInput{
+		ServiceInstanceID: instanceName,
+		Description:       _TestAccessRuleDescription,
+		Destination:       AccessRuleDefaultDestination,
+		Ports:             _TestAccessRulePorts,
+		Name:              _TestAccessRuleName,
+		Source:            _TestAccessRuleSource,
+		Status:            AccessRuleDisabled,
+	}
+
+	expected := &AccessRuleInfo{
+		Description: _TestAccessRuleDescription,
+		Destination: AccessRuleDefaultDestination,
+		Ports:       _TestAccessRulePorts,
+		Name:        _TestAccessRuleName,
+		Source:      _TestAccessRuleSource,
+		Status:      AccessRuleDisabled,
+		RuleType:    "USER",
+	}
+
+	// Create Access Rule
+	if _, err := aClient.CreateAccessRule(input); err != nil {
+		t.Fatalf("Error creating AccessRule: %s", err)
+	}
+	defer destroyAccessRule(t, aClient, instanceName, _TestAccessRuleName)
+
+	// Get Access Rule (Create only returns AccessRule name)
+	getInput := &GetAccessRuleInput{
+		ServiceInstanceID: instanceName,
+		Name:              _TestAccessRuleName,
+	}
+
+	// Read Result
+	result, err := aClient.GetAccessRule(getInput)
+	if err != nil {
+		t.Fatalf("Error reading AccessRule: %s", err)
+	}
+
+	// Test Assertions
+	if diff := pretty.Compare(result, expected); diff != "" {
+		t.Fatalf("Diff creating AccessRule: (-got, +want):\n%s", diff)
+	}
+
+	// Update Access Rule
+	updateInput := &UpdateAccessRuleInput{
+		ServiceInstanceID: instanceName,
+		Name:              _TestAccessRuleName,
+		Status:            AccessRuleEnabled,
+	}
+
+	if _, err := aClient.UpdateAccessRule(updateInput); err != nil {
+		t.Fatalf("Error updating AccessRule: %s", err)
+	}
+
+	// Re-Read Result
+	result, err = aClient.GetAccessRule(getInput)
+	if err != nil {
+		t.Fatalf("Error reading AccessRule: %s", err)
+	}
+
+	// Change expected to match
+	expected.Status = AccessRuleEnabled
+
+	// Test Assertions
+	if diff := pretty.Compare(result, expected); diff != "" {
+		t.Fatalf("Diff creating AccessRule: (-got, +want):\n%s", diff)
+	}
+}
+
+func getAccessRulesTestClients() (*ServiceInstanceClient, *UtilityClient, error) {
+	client, err := GetDatabaseTestClient(&opc.Config{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return client.ServiceInstanceClient(), client.AccessRules(), nil
+}
+
+func destroyAccessRule(t *testing.T, client *UtilityClient, serviceInstance, name string) {
+	input := &DeleteAccessRuleInput{
+		Name:              name,
+		ServiceInstanceID: serviceInstance,
+	}
+	if err := client.DeleteAccessRule(input); err != nil {
+		t.Fatalf("Error deleting Access Rule: %s", err)
+	}
+}
+
+func (c *ServiceInstanceClient) createTestServiceInstance() (*ServiceInstance, error) {
+	parameter := ParameterInput{
+		AdminPassword:     _ServiceInstancePassword,
+		BackupDestination: _ServiceInstanceBackupDestination,
+		SID:               _ServiceInstanceDBSID,
+		Type:              _ServiceInstanceType,
+		UsableStorage:     _ServiceInstanceUsableStorage,
+	}
+
+	createServiceInstance := &CreateServiceInstanceInput{
+		Name:             fmt.Sprintf("test-acc-instance-%d", helper.RInt()),
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscription,
+		Version:          _ServiceInstanceVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        parameter,
+	}
+
+	return c.CreateServiceInstance(createServiceInstance)
+}

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -43,6 +43,8 @@ func (c *DatabaseClient) executeRequest(method, path string, body interface{}) (
 	debugReqString := fmt.Sprintf("HTTP %s Req (%s)", method, path)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+		// Debug the body for database services
+		debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, body)
 	}
 	// Log the request before the authentication header, so as not to leak credentials
 	c.client.DebugLogString(debugReqString)
@@ -50,10 +52,9 @@ func (c *DatabaseClient) executeRequest(method, path string, body interface{}) (
 	// Set the authentiation headers
 	req.Header.Add(AUTH_HEADER, *c.authHeader)
 	req.Header.Add(TENANT_HEADER, *c.client.IdentityDomain)
-	c.client.DebugLogString(fmt.Sprintf("Req (%+v)", req))
 	resp, err := c.client.ExecuteRequest(req)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }

--- a/database/database_resource_client.go
+++ b/database/database_resource_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/go-oracle-terraform/opc"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -49,15 +50,32 @@ func (c *ResourceClient) getResource(name string, responseBody interface{}) erro
 	return c.unmarshalResponseBody(resp, responseBody)
 }
 
-func (c *ResourceClient) deleteResource(name string, body interface{}) error {
+// This is only used for deleting service instances. DELETE requests have a `nil` body.
+func (c *ResourceClient) deleteResource(name string, backups bool) error {
 	var objectPath string
 	if name != "" {
 		objectPath = c.getObjectPath(c.ResourceRootPath, name)
 	} else {
 		objectPath = c.ResourceRootPath
 	}
-	_, err := c.executeRequest("DELETE", objectPath, body)
+
+	// Set deleteBackup
+	if backups {
+		objectPath = fmt.Sprintf("%s?deleteBackup=true", objectPath)
+	}
+
+	_, err := c.executeRequest("DELETE", objectPath, nil)
 	if err != nil {
+		if v, ok := err.(*opc.OracleError); ok {
+			if v.StatusCode == 404 {
+				// Object can't be found, doesn't exist, no error
+				return nil
+			} else {
+				return fmt.Errorf("Error on delete (%d): %s", v.StatusCode, v.Message)
+			}
+		}
+
+		// Otherwise, something went wrong.
 		return err
 	}
 

--- a/database/database_resource_client.go
+++ b/database/database_resource_client.go
@@ -70,9 +70,8 @@ func (c *ResourceClient) deleteResource(name string, backups bool) error {
 			if v.StatusCode == 404 {
 				// Object can't be found, doesn't exist, no error
 				return nil
-			} else {
-				return fmt.Errorf("Error on delete (%d): %s", v.StatusCode, v.Message)
 			}
+			return fmt.Errorf("Error on delete (%d): %s", v.StatusCode, v.Message)
 		}
 
 		// Otherwise, something went wrong.

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"log"
+
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-oracle-terraform/client"
 )
 
@@ -572,16 +575,16 @@ func (c *ServiceInstanceClient) GetServiceInstance(getInput *GetServiceInstanceI
 type DeleteServiceInstanceInput struct {
 	// Name of the Database Cloud Service instance.
 	// Required.
-	Name string `json:"-"`
+	Name string
 	// Flag that when set to true deletes all backups of the service instance from Oracle Cloud Storage container.
 	// Use caution in specifying this option. If this option is specified, instance can not be recovered as all backups
 	// will be deleted. This option is not currently supported for Cluster Databases.
 	// Default value is false.
 	// Optional
-	DeleteBackup bool `json:"deleteBackup"`
+	DeleteBackup bool
 }
 
-func (c *ServiceInstanceClient) DeleteServiceInstance(deleteInput *DeleteServiceInstanceInput) error {
+func (c *ServiceInstanceClient) DeleteServiceInstance(input *DeleteServiceInstanceInput) error {
 	if c.Timeout == 0 {
 		c.Timeout = WaitForServiceInstanceDeleteTimeout
 	}
@@ -590,7 +593,8 @@ func (c *ServiceInstanceClient) DeleteServiceInstance(deleteInput *DeleteService
 	// An instance takes additional time to setup after it's configured.
 	var deleteErr error
 	for i := 0; i < ServiceInstanceDeleteRetry; i++ {
-		if deleteErr = c.deleteResource(deleteInput.Name, deleteInput); deleteErr != nil {
+		if deleteErr = c.deleteResource(input.Name, input.DeleteBackup); deleteErr != nil {
+			log.Printf("Error during delete, waiting 30s: %s", spew.Sdump(deleteErr))
 			time.Sleep(30 * time.Second)
 			continue
 		}
@@ -602,7 +606,7 @@ func (c *ServiceInstanceClient) DeleteServiceInstance(deleteInput *DeleteService
 
 	// Call wait for instance deleted now, as deleting the instance is an eventually consistent operation
 	getInput := &GetServiceInstanceInput{
-		Name: deleteInput.Name,
+		Name: input.Name,
 	}
 
 	// Wait for instance to be deleted

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -6,7 +6,6 @@ import (
 
 	"log"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-oracle-terraform/client"
 )
 
@@ -594,7 +593,7 @@ func (c *ServiceInstanceClient) DeleteServiceInstance(input *DeleteServiceInstan
 	var deleteErr error
 	for i := 0; i < ServiceInstanceDeleteRetry; i++ {
 		if deleteErr = c.deleteResource(input.Name, input.DeleteBackup); deleteErr != nil {
-			log.Printf("Error during delete, waiting 30s: %s", spew.Sdump(deleteErr))
+			log.Printf("Error during delete, waiting 30s: %+v", deleteErr)
 			time.Sleep(30 * time.Second)
 			continue
 		}

--- a/database/ssh_keys.go
+++ b/database/ssh_keys.go
@@ -1,0 +1,175 @@
+// Manages SSH Keys for a DBaaS Service Instance.
+// SSH Keys can currently only be created and information fetched. They cannot
+// be updated, or deleted via the API. So each interaction requires a ForceNew
+// and "deleting" the resource simply removes the resource from state
+// (in the provider), as there is no Delete method on the ssh key resource's
+// API.
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// API URI Paths for Container and Root objects.
+// API Docs state to always set the 'credentialName' attribute in the
+// resource's path to 'vmspublickey'. Hard-coding for now, but a better solution
+// may need to be solved for SSH Keys if this value ever needs to be changed.
+// See: https://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/op-paas-api-v1.1-instancemgmt-%7BidentityDomainId%7D-services-dbaas-instances-%7BserviceId%7D-credentials-crednames-%7BcredentialName%7D-post.html
+// for more details on 'credentialName'.
+
+// The Root Path, for SSH Keys also does not expect a conventional 'Name'
+// path parameter, and the only difference between creating an SSH Key
+// and viewing the summary of the current SSH Key is a PUT vs GET HTTP Method.
+const (
+	DBSSHKeyContainerPath = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/credentials/crednames/vmspublickey"
+	DBSSHKeyRootPath      = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/credentials/%s"
+	DBSSHKeyName          = "vmspublickey"
+)
+
+// Default timeout value for Create
+// In testing this is anywhere between 10-20s depending on if it's a new SSH Key
+// or if it's an "updated" ssh key.
+const WaitForSSHKeyTimeout = time.Duration(30 * time.Second)
+
+// SSHKeys returns a UtilityClient for managing SSHKeys for a DBaaS Service Instance
+func (c *DatabaseClient) SSHKeys() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    DBSSHKeyContainerPath,
+			ResourceRootPath: DBSSHKeyRootPath,
+		},
+	}
+}
+
+// SSHKeyInfo holds all the known information for a single SSH Key
+type SSHKeyInfo struct {
+	// This will likely always be "DB".
+	ComponentType string `json:"componentType"`
+	// The fully qualified name of the SSH Key object in OPC Cloud Storage
+	// where the SSH public key value is stored.
+	ComputeKeyName string `json:"computeKeyName"`
+	// Should always be 'vmspublickey'
+	CredName string `json:"credName"`
+	// Should always be SSH
+	CredType string `json:"credType"`
+	// The string description of the key
+	Description string `json:"description"`
+	// Note: The API supplies us with the 'identityDomain' key here,
+	// but since we are required to supply this during the API request
+	// and it's already a "known" value, we don't return the value here as well.
+
+	// The message returned from the last update of the SSH Key.
+	LastUpdateMessage string `json:"lastUpdateMessage"`
+	// Status of the last update of the SSH key
+	LastUpdateStatus string `json:"lastUpdateStatus"`
+	// Date and time of the last update of the SSH Key
+	LastUpdateTime string `json:"lastUpdateTime"`
+	// The value "opc"
+	OsUserName string `json:"osUserName"`
+	// The value "SERVICE"
+	ParentType string `json:"parentType"`
+	// The Value of the SSH Public Key with any slashes (/) it contains
+	// preceded by backslashes: \/.
+	PublicKey string `json:"publicKey"`
+	// The name of the DatabaseCloudService Instance
+	ServiceName string `json:"serviceName"`
+	// The value "DBaaS"
+	ServiceType string `json:"serviceType"`
+}
+
+// CreateSSHKeyInput defines the necessary input parameters to create an
+// SSH Key for a DBaaS Service Instance
+type CreateSSHKeyInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// The value of the SSH public key, with any slashes (/) it contains preceded by
+	// backslashes, as in \/.
+	// Required
+	PublicKey string `json:"public-key"`
+	// Time to wait for an ssh key to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Creates an SSH Key with the supplied input struct.
+func (c *UtilityClient) CreateSSHKey(input *CreateSSHKeyInput) (*SSHKeyInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var sshKey SSHKeyInfo
+	if err := c.createResource(input, &sshKey); err != nil {
+		return nil, err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForSSHKeyTimeout
+	}
+
+	// Can leave ServiceInstanceID nil here, it will be the same as the current client's
+	result, err := c.WaitForSSHKeyReady(&GetSSHKeyInput{}, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetSSHKeyInput defines all of the necessary input parameters to retrieve the necessary
+// information on a specific SSH Key.
+type GetSSHKeyInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+}
+
+// Get's information on a single SSH Key
+func (c *UtilityClient) GetSSHKey(input *GetSSHKeyInput) (*SSHKeyInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Name has to be populated in this case as the Container path and the Root path are completely
+	// separate paths. Otherwise, with a nil name, the Container path would have been used, which
+	// would effectively return a '200 OK' for each request, but only return the summary for an SSH Key
+	// instead of details
+	var sshKey SSHKeyInfo
+	if err := c.getResource(DBSSHKeyName, &sshKey); err != nil {
+		return nil, err
+	}
+
+	return &sshKey, nil
+}
+
+// No Delete, or Update currently.
+// TODO: Add Delete and Update for SSH Keys when they are available in the API.
+
+func (c *UtilityClient) WaitForSSHKeyReady(input *GetSSHKeyInput, timeout time.Duration) (*SSHKeyInfo, error) {
+	var info *SSHKeyInfo
+	var getErr error
+	err := c.client.WaitFor("sshkey to be ready", timeout, func() (bool, error) {
+		info, getErr = c.GetSSHKey(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		if info != nil {
+			if strings.ToLower(info.LastUpdateStatus) == "success" {
+				// SSH Key found, and completed, return. Desired case.
+				return true, nil
+			} else {
+				c.client.DebugLogString(fmt.Sprintf("SSH Key Status: %s",
+					strings.ToLower(info.LastUpdateStatus)))
+				return false, nil
+			}
+		}
+		// Not found, wait
+		c.client.DebugLogString(fmt.Sprintf("SSH Key not found, waiting"))
+		return false, nil
+	})
+	return info, err
+}

--- a/database/ssh_keys.go
+++ b/database/ssh_keys.go
@@ -158,14 +158,9 @@ func (c *UtilityClient) WaitForSSHKeyReady(input *GetSSHKeyInput, timeout time.D
 			return false, getErr
 		}
 		if info != nil {
-			if strings.ToLower(info.LastUpdateStatus) == "success" {
-				// SSH Key found, and completed, return. Desired case.
-				return true, nil
-			} else {
-				c.client.DebugLogString(fmt.Sprintf("SSH Key Status: %s",
-					strings.ToLower(info.LastUpdateStatus)))
-				return false, nil
-			}
+			c.client.DebugLogString(fmt.Sprintf("SSH Key Status: %s", strings.ToLower(info.LastUpdateStatus)))
+			success := strings.ToLower(info.LastUpdateStatus) == "success"
+			return success, nil
 		}
 		// Not found, wait
 		c.client.DebugLogString(fmt.Sprintf("SSH Key not found, waiting"))

--- a/database/ssh_keys_test.go
+++ b/database/ssh_keys_test.go
@@ -1,0 +1,117 @@
+package database
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+// Test Constants
+const (
+	_TestSSHServiceType      = "DBaaS"
+	_TestSSHCredType         = "SSH"
+	_TestSSHComponentType    = "DB"
+	_TestSSHParentType       = "SERVICE"
+	_TestSSHLastUpdateStatus = "SUCCESS"
+	_TestSSHOsUserName       = "opc"
+)
+
+func TestAccSSHKeysLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	serviceClient, sshClient, err := getSSHKeyTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var instanceName string
+	if v := os.Getenv("OPC_TEST_DB_INSTANCE"); v == "" {
+		// First Create a Service Instance
+		sInstance, err := serviceClient.createTestServiceInstance()
+		if err != nil {
+			t.Fatalf("Error creating Service Instance: %v", err)
+		}
+		defer destroyServiceInstance(t, serviceClient, sInstance.Name)
+		instanceName = sInstance.Name
+	} else {
+		log.Print("Using already created DB Service Instance")
+		instanceName = v
+	}
+
+	// Create an SSH Key
+	input := &CreateSSHKeyInput{
+		ServiceInstanceID: instanceName,
+		PublicKey:         _TestSSHKeyPublicKey,
+	}
+
+	// Create SSH Key
+	if _, err := sshClient.CreateSSHKey(input); err != nil {
+		t.Fatalf("Error creating SSH Key: %v", err)
+	}
+
+	// Get Input
+	getInput := &GetSSHKeyInput{
+		ServiceInstanceID: instanceName,
+	}
+
+	res, err := sshClient.GetSSHKey(getInput)
+	if err != nil {
+		t.Fatalf("Error retrieving SSH Key: %v", err)
+	}
+
+	// Verify un-testable fields are not nil
+	if res.LastUpdateTime == "" {
+		t.Fatalf("Expected value for LastUpdateTime, got nil")
+	}
+	res.LastUpdateTime = ""
+
+	if res.LastUpdateMessage == "" {
+		t.Fatalf("Expected value for LastUpdateMessage, got nil")
+	}
+	res.LastUpdateMessage = ""
+
+	if res.ComputeKeyName == "" {
+		t.Fatalf("Expected value for ComputeKeyName, got nil")
+	}
+	res.ComputeKeyName = ""
+
+	expected := &SSHKeyInfo{
+		ServiceType:       _TestSSHServiceType,
+		ServiceName:       instanceName,
+		CredName:          DBSSHKeyName,
+		CredType:          _TestSSHCredType,
+		ComponentType:     _TestSSHComponentType,
+		ParentType:        _TestSSHParentType,
+		OsUserName:        _TestSSHOsUserName,
+		PublicKey:         _TestSSHKeyPublicKey,
+		Description:       _TestSSHKeyDescription,
+		LastUpdateStatus:  _TestSSHLastUpdateStatus,
+		LastUpdateTime:    "",
+		LastUpdateMessage: "",
+		ComputeKeyName:    "",
+	}
+
+	if diff := pretty.Compare(res, expected); diff != "" {
+		t.Fatalf("Diff on SSH Key: (-got +want)\n%s", diff)
+	}
+
+}
+
+func getSSHKeyTestClients() (*ServiceInstanceClient, *UtilityClient, error) {
+	client, err := GetDatabaseTestClient(&opc.Config{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return client.ServiceInstanceClient(), client.SSHKeys(), nil
+}
+
+// Testing SSH Key. Breaking constant convention by placing at bottom of file
+// because a super long string is ugly.
+const (
+	_TestSSHKeyPublicKey   = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5VoI2s4GYbVP/Gr3OBxZi5twtupnXc1gknedifREIBb5m7MxRmtL9ffQS7ZY1emYKey7oCs/7R/1Ta7UdV2BBFk++np3t1HUbcaFeBADZVdqavAv28waDBV78dUarDw4aTGzDtqnATz1AWYV4mtsrUeBhtdHBMgTnnm7V1U2NzIYArBs43tvLfulcWfwU/2goK6kfmi21fECJYF5uim7Nlqtgf7ynwCoLlJGNJxn6u8xQzTqmOrScbzno8oUbk3+Rnds+El0/P3mavETr2gVQVvGjmrTWoN8j6g+QjhKudU5C3PjI2MaFjdRnLcwabjJYaF1p69o1LXY+DtD42xtQ99wtfhLTAwDELNYHKcV/xJbgRPfBLXPltZys+LUT/RrhvHZ8d7Urp2FuOgl8KGreE/XH6oDVU0MT01SeLiJeAA951lpMTXmWErm5DRBHHQZ9Bq8ZHzsdqxSUUQK2SHhXnQolqlJRTr9m1o6XDA8Xcq+buMI7LT8A2wTYHbr6pmrDy1CgWVOreHuo+gZegKkFuZKsubXzeCubgHdproOlph84OjLOpdMC11XAUdvO47APNkjdEA1wfRQAxpREI9yymItmHdc81fsBBkTyH5teUVQjvPk/VoVganKqNBUyAwbVZZLdkS3lQCxAtgBg4i1XFwNP+AaA18EtZcMca/1Ykw==`
+	_TestSSHKeyDescription = `Service user ssh public key which can be used to access the service VM instances`
+)

--- a/database/utility_resource_client.go
+++ b/database/utility_resource_client.go
@@ -9,6 +9,15 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// The UtilityClient which extends the UtilityResourceClient.
+// This is purely because utility resources (SSH Keys + Access Rules) include the service
+// instance name in the URL path for managing these resources, so we cannot use the same
+// resource client that the service instance uses. We're still using the same OPC client, just
+// abstracting the path helper functions to make life a little easier.
+type UtilityClient struct {
+	UtilityResourceClient
+}
+
 // UtilityResourceClient is a client to manage resources on an already created service instance
 type UtilityResourceClient struct {
 	*DatabaseClient

--- a/database/utility_resource_client.go
+++ b/database/utility_resource_client.go
@@ -1,0 +1,106 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// UtilityResourceClient is a client to manage resources on an already created service instance
+type UtilityResourceClient struct {
+	*DatabaseClient
+	ContainerPath     string
+	ResourceRootPath  string
+	ServiceInstanceID string
+}
+
+func (c *UtilityResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UtilityResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
+	resp, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.getContainerPath(c.ContainerPath)
+	}
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) deleteResource(name string, body interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	_, err := c.executeRequest("DELETE", objectPath, body)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}
+
+func (c *UtilityResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err := dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("%+v", resp)
+		return err
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UtilityResourceClient) getContainerPath(root string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/dbaas/instances/{serviceId}/accessrules
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID)
+}
+
+func (c *UtilityResourceClient) getObjectPath(root, name string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/dbaas/instances/{serviceId}/accessrules/{ruleName}
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID, name)
+}

--- a/database/utility_test.go
+++ b/database/utility_test.go
@@ -1,0 +1,46 @@
+package database
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+)
+
+// WARNING: This _will_ leak a DB instance, that needs to be removed either manually,
+// or via a manual API call. Useful for local test iterations, as it takes > 1 hour to
+// spin up and shut down a DB Test Instance. The resulting test instance
+// can be used in utility tests for access rules and ssh keys by populating the
+// OPC_TEST_DB_INSTANCE environment variable with the full name of the created service instance.
+func TestAccDataBaseClient_CreateStandalone(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+	if v := os.Getenv("OPC_TEST_DB"); v == "" {
+		t.Skip("Skipping Database Standalone Instance Create")
+	}
+	client, err := getServiceInstanceTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sInstance, err := client.createTestServiceInstance()
+	if err != nil {
+		t.Fatalf("Error creating service instance: %s", err)
+	}
+	t.Logf("Created Service Instance: %s", sInstance.Name)
+}
+
+// This is another helper test function similar to the above TestAccDataBaseClient_CreateStandalone,
+// however, this will attempt to destroy the service instance found in the env var
+// OPC_TEST_DB_INSTANCE. If no instance is specified at env var, exits cleanly.
+func TestAccDataBaseClient_DestroyStandalone(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+	instance := os.Getenv("OPC_TEST_DB_INSTANCE")
+	if instance == "" {
+		t.Skip("No DB Instance to destroy")
+	}
+	client, err := getServiceInstanceTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Attempt to destroy the service instance
+	destroyServiceInstance(t, client, instance)
+}


### PR DESCRIPTION
- [X] Add Access Rules
- [X] Add Access Rules acceptance tests
- [X] Add Utility Resource helper functions
- [X] Fix ServiceInstance Client. Delete Request should have a `nil` body
- [X] Add SSH Key Resource
- [ ] Find out why API always returns a `500` on instance termination, even though service instance is correctly terminated.

Bugfix: 
- Fixes Debug Log issue where HTTP Request bodies were no longer being printed in their actual JSON form, but the Golang Struct that built the JSON request. This was fixed by splitting out the JSON marshaling from the request building, and deprecates the original `BuidlRequest` method.

Note: Adds two helper functions for iterating and working on PaaS DB resources.
`TestAccDataBaseClient_CreateStandalone` and `TestAccDataBaseClient_DestroyStandalone`.

`TestAccDataBaseClient_CreateStandalone`, will only run if the
`OPC_TEST_DB` environment variable is populated. This ensure's we don't
leak service instances during our nightly acceptance tests, as this env
var will not be set. The test function, when ran like so:

```
$ OPC_TEST_DB=1 make testacc TEST=./database TESTARGS="-run=TestAccDataBaseClient_CreateStandalone"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccDataBaseClient_CreateStandalone -timeout 120m
=== RUN   TestAccDataBaseClient_CreateStandalone
--- PASS: TestAccDataBaseClient_CreateStandalone (2103.38s)
	utility_test.go:28: Created Service Instance: test-acc-instance-1477082219030707041
PASS
ok  	github.com/hashicorp/go-oracle-terraform/database	2103.388s
```

Will create a database service instance, and print the resulting instance name.
The service instance can then be used in utility resource acceptance tests.
If the `OPC_TEST_DB_INSTANCE` environment variable is _not_ set, a new
service instance is created. This takes well over an hour though, which is the
entire reason why these helper functions were added. Using the pre-created
service instance, running acceptance tests are like so:

```
$ OPC_TEST_DB_INSTANCE="test-acc-instance-2585833497402570070" make testacc TEST=./database TESTARGS="-run=TestAccAccessRulesLifeCycle"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccAccessRulesLifeCycle -timeout 120m
=== RUN   TestAccAccessRulesLifeCycle
--- PASS: TestAccAccessRulesLifeCycle (33.40s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/database	33.399s
```

Then, removing the service instance simply requires a call to
`TestAccDataBaseClient_DestroyStandalone`, like so:

```
OPC_TEST_DB_INSTANCE="test-acc-instance-3571425565140711367" make testacc TEST=./database TESTARGS="-run=TestAccDataBaseClient_DestroyStandalone"
```

Due to the extra environment variables that need to be specified during the test,
this has no adverse side affects to our automated smoke test setup, nor
any tests that are ran without manually specifying these environment variables.

## SSH Keys

```
$ OPC_TEST_DB_INSTANCE=test-acc-instance-2211631074654405438 make testacc TEST=./database TESTARGS="-run=TestAccSSHKeysLifeCycle"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccSSHKeysLifeCycle -timeout 120m
=== RUN   TestAccSSHKeysLifeCycle
--- PASS: TestAccSSHKeysLifeCycle (16.30s)
PASS
ok      github.com/hashicorp/go-oracle-terraform/database       16.317s
```