### PR TITLE
P java service instance

### DIFF
--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1013,7 +1013,7 @@ type Parameter struct {
 	// Note: This attribute is valid when component type is set to datagrid only; it is not valid for weblogic or otd.
 	// Required when using a custom capacity unit only. Groups attributes for a custom capacity unit.
 	// Optional.
-	ScalingUnit ScalingUnit `json:"scalingUnit,omitempty"`
+	ScalingUnits []ScalingUnit `json:"scalingUnit,omitempty"`
 	// Note: This attribute is valid when component type is set to datagrid only;
 	// it is not valid for weblogic or otd.
 	// The number of capacity units to add.
@@ -1152,7 +1152,7 @@ type ScalingUnit struct {
 	// copy of the Coherence data, so the actual data available might be more than 1/3 of the JVM heap size.
 	// Use a number from 1 GB to 16 GB.
 	// Required.
-	HeapSize int `json:"heapSize"`
+	HeapSize string `json:"heapSize"`
 	// Number of JVMs to start on each VM.
 	// Use a number from 1 to 8.
 	// Required.

--- a/java/service_instance_test.go
+++ b/java/service_instance_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	_ServiceInstanceName                        = "testingjavaserviceinstancea"
+	_ServiceInstanceName                        = "testingjavaserviceinstance"
 	_ServiceInstanceLevel                       = "PAAS"
 	_ServiceInstanceSubscriptionType            = "HOURLY"
 	_ServiceInstanceType                        = "weblogic"
@@ -21,7 +21,7 @@ const (
 	_ServiceInstanceAdminUsername               = "sdk-user"
 	_ServiceInstanceAdminPassword               = "Test_String7"
 	_ServiceInstancePubKey                      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
-	_ServiceInstanceCloudStorageContainer       = "Storage-canonical/test-java-instance"
+	_ServiceInstanceCloudStorageContainer       = "Storage-a459477/test-java-instance"
 	_ServiceInstanceCloudStorageCreateIfMissing = true
 	// Database specific configuration
 	_ServiceInstanceDatabaseName            = "testing-java-instance-service"
@@ -29,7 +29,7 @@ const (
 	_ServiceInstanceDBSID                   = "ORCL"
 	_ServiceInstanceDBType                  = "db"
 	_ServiceInstanceUsableStorage           = "15"
-	_ServiceInstanceDBCloudStorageContainer = "Storage-canonical/test-db-java-instance"
+	_ServiceInstanceDBCloudStorageContainer = "Storage-a459477/test-db-java-instance"
 	_ServiceInstanceEdition                 = "EE_EP"
 	_ServiceInstanceDBVersion               = "12.2.0.1"
 )
@@ -107,6 +107,209 @@ func TestAccServiceInstanceLifeCycle(t *testing.T) {
 	}
 	if receivedRes.ServiceName != _ServiceInstanceName {
 		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", _ServiceInstanceName, receivedRes.ServiceName))
+	}
+}
+
+func TestAccServiceInstanceLifeCycle_typeOTD(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	// siClient, dClient, err := getServiceInstanceTestClients()
+	siClient, _, err := getServiceInstanceTestClients()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	/*
+		databaseParameter := database.ParameterInput{
+			AdminPassword:                   _ServiceInstanceDBAPassword,
+			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+			SID:                             _ServiceInstanceDBSID,
+			Type:                            _ServiceInstanceDBType,
+			UsableStorage:                   _ServiceInstanceUsableStorage,
+			CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
+			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+		}
+
+		createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
+			Name:             _ServiceInstanceDatabaseName,
+			Edition:          _ServiceInstanceEdition,
+			Level:            _ServiceInstanceLevel,
+			Shape:            _ServiceInstanceShape,
+			SubscriptionType: _ServiceInstanceSubscriptionType,
+			Version:          _ServiceInstanceDBVersion,
+			VMPublicKey:      _ServiceInstancePubKey,
+			Parameter:        databaseParameter,
+		}
+
+		_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName) */
+
+	webLogicParameter := Parameter{
+		Type:          ServiceInstanceTypeWebLogic,
+		DBAName:       _ServiceInstanceDBAUser,
+		DBAPassword:   _ServiceInstanceDBAPassword,
+		DBServiceName: "test-service-instance-matthew",
+		Shape:         _ServiceInstanceShape,
+		Version:       _ServiceInstanceVersion,
+		AdminUsername: _ServiceInstanceAdminUsername,
+		AdminPassword: _ServiceInstanceAdminPassword,
+		VMsPublicKey:  _ServiceInstancePubKey,
+	}
+
+	otdParameter := Parameter{
+		Type:          ServiceInstanceTypeOTD,
+		AdminUsername: _ServiceInstanceAdminUsername,
+		AdminPassword: _ServiceInstanceAdminPassword,
+		Shape:         _ServiceInstanceShape,
+		VMsPublicKey:  _ServiceInstancePubKey,
+	}
+
+	siName := fmt.Sprintf("%s-otda", _ServiceInstanceName)
+	createServiceInstance := &CreateServiceInstanceInput{
+		ProvisionOTD:                    true,
+		CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+		ServiceName:                     siName,
+		Level:                           _ServiceInstanceLevel,
+		SubscriptionType:                _ServiceInstanceSubscriptionType,
+		Parameters:                      []Parameter{webLogicParameter, otdParameter},
+	}
+
+	_, err = siClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer destroyServiceInstance(t, siClient, siName)
+
+	getInput := &GetServiceInstanceInput{
+		Name: siName,
+	}
+
+	receivedRes, err := siClient.GetServiceInstance(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.ServiceName != siName {
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", siName, receivedRes.ServiceName))
+	}
+	if receivedRes.OTDAdminURL == "" {
+		t.Fatal(fmt.Errorf("OTD was unsuccessfully provisioned: %+v", receivedRes))
+	}
+}
+
+func TestAccServiceInstanceLifeCycle_typeDatagrid(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	// siClient, dClient, err := getServiceInstanceTestClients()
+	siClient, _, err := getServiceInstanceTestClients()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	/*
+		databaseParameter := database.ParameterInput{
+			AdminPassword:                   _ServiceInstanceDBAPassword,
+			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+			SID:                             _ServiceInstanceDBSID,
+			Type:                            _ServiceInstanceDBType,
+			UsableStorage:                   _ServiceInstanceUsableStorage,
+			CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
+			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+		}
+
+		createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
+			Name:             _ServiceInstanceDatabaseName,
+			Edition:          _ServiceInstanceEdition,
+			Level:            _ServiceInstanceLevel,
+			Shape:            _ServiceInstanceShape,
+			SubscriptionType: _ServiceInstanceSubscriptionType,
+			Version:          _ServiceInstanceDBVersion,
+			VMPublicKey:      _ServiceInstancePubKey,
+			Parameter:        databaseParameter,
+		}
+
+		_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName) */
+
+	/*
+		scalingUnit := ScalingUnit{
+			Shape:    "oc3",
+			VMCount:  1,
+			HeapSize: "4G",
+			JVMCount: 2,
+		} */
+
+	datagridParameter := Parameter{
+		Type:             ServiceInstanceTypeDataGrid,
+		ScalingUnitCount: 1,
+		ClusterName:      "testDataGrid",
+		ScalingUnitName:  "SMALL",
+		// ScalingUnits:     []ScalingUnit{scalingUnit},
+	}
+
+	webLogicParameter := Parameter{
+		Type:          ServiceInstanceTypeWebLogic,
+		Edition:       ServiceInstanceEditionSuite,
+		DBAName:       _ServiceInstanceDBAUser,
+		DBAPassword:   _ServiceInstanceDBAPassword,
+		DBServiceName: "test-service-instance-matthew",
+		Shape:         _ServiceInstanceShape,
+		Version:       _ServiceInstanceVersion,
+		AdminUsername: _ServiceInstanceAdminUsername,
+		AdminPassword: _ServiceInstanceAdminPassword,
+		VMsPublicKey:  _ServiceInstancePubKey,
+	}
+
+	siName := fmt.Sprintf("%s-datagrid", _ServiceInstanceName)
+	createServiceInstance := &CreateServiceInstanceInput{
+		CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+		ServiceName:                     siName,
+		Level:                           _ServiceInstanceLevel,
+		SubscriptionType:                _ServiceInstanceSubscriptionType,
+		Parameters:                      []Parameter{webLogicParameter, datagridParameter},
+	}
+
+	_, err = siClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer destroyServiceInstance(t, siClient, siName)
+
+	getInput := &GetServiceInstanceInput{
+		Name: siName,
+	}
+
+	receivedRes, err := siClient.GetServiceInstance(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.ServiceName != siName {
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", siName, receivedRes.ServiceName))
+	}
+
+	if len(receivedRes.Options) > 0 {
+		option := receivedRes.Options[0]
+		if len(option.Clusters) > 0 {
+			cluster := option.Clusters[0]
+			if cluster.ScalingUnitCount != 1 {
+				t.Fatal(fmt.Errorf("Scaling unit counts don't match. Wanted: %d Received %d", 1, cluster.ScalingUnitCount))
+			}
+		} else {
+			t.Fatal(fmt.Errorf("Error reading cluster for Scaling Units: %+v", option.Clusters))
+		}
+	} else {
+		t.Fatal(fmt.Errorf("Error reading Options for Scaling Units: %+v", receivedRes))
 	}
 }
 

--- a/java/service_instance_test.go
+++ b/java/service_instance_test.go
@@ -192,7 +192,7 @@ func TestAccServiceInstanceLifeCycle_typeOTD(t *testing.T) {
 		t.Fatal(err)
 	}
 	if receivedRes.ServiceName != siName {
-		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", siName, receivedRes.ServiceName))
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %q Received: %q", siName, receivedRes.ServiceName))
 	}
 	if receivedRes.OTDAdminURL == "" {
 		t.Fatal(fmt.Errorf("OTD was unsuccessfully provisioned: %+v", receivedRes))
@@ -280,7 +280,7 @@ func TestAccServiceInstanceLifeCycle_typeDatagrid(t *testing.T) {
 		t.Fatal(err)
 	}
 	if receivedRes.ServiceName != siName {
-		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", siName, receivedRes.ServiceName))
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %q Received: %q", siName, receivedRes.ServiceName))
 	}
 
 	if len(receivedRes.Options) > 0 {

--- a/java/service_instance_test.go
+++ b/java/service_instance_test.go
@@ -113,46 +113,43 @@ func TestAccServiceInstanceLifeCycle(t *testing.T) {
 func TestAccServiceInstanceLifeCycle_typeOTD(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
-	// siClient, dClient, err := getServiceInstanceTestClients()
-	siClient, _, err := getServiceInstanceTestClients()
-
+	siClient, dClient, err := getServiceInstanceTestClients()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	/*
-		databaseParameter := database.ParameterInput{
-			AdminPassword:                   _ServiceInstanceDBAPassword,
-			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
-			SID:                             _ServiceInstanceDBSID,
-			Type:                            _ServiceInstanceDBType,
-			UsableStorage:                   _ServiceInstanceUsableStorage,
-			CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
-			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
-		}
+	databaseParameter := database.ParameterInput{
+		AdminPassword:                   _ServiceInstanceDBAPassword,
+		BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+		SID:                             _ServiceInstanceDBSID,
+		Type:                            _ServiceInstanceDBType,
+		UsableStorage:                   _ServiceInstanceUsableStorage,
+		CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+	}
 
-		createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
-			Name:             _ServiceInstanceDatabaseName,
-			Edition:          _ServiceInstanceEdition,
-			Level:            _ServiceInstanceLevel,
-			Shape:            _ServiceInstanceShape,
-			SubscriptionType: _ServiceInstanceSubscriptionType,
-			Version:          _ServiceInstanceDBVersion,
-			VMPublicKey:      _ServiceInstancePubKey,
-			Parameter:        databaseParameter,
-		}
+	createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
+		Name:             _ServiceInstanceDatabaseName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscriptionType,
+		Version:          _ServiceInstanceDBVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        databaseParameter,
+	}
 
-		_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName) */
+	_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName)
 
 	webLogicParameter := Parameter{
 		Type:          ServiceInstanceTypeWebLogic,
 		DBAName:       _ServiceInstanceDBAUser,
 		DBAPassword:   _ServiceInstanceDBAPassword,
-		DBServiceName: "test-service-instance-matthew",
+		DBServiceName: _ServiceInstanceDatabaseName,
 		Shape:         _ServiceInstanceShape,
 		Version:       _ServiceInstanceVersion,
 		AdminUsername: _ServiceInstanceAdminUsername,
@@ -205,55 +202,43 @@ func TestAccServiceInstanceLifeCycle_typeOTD(t *testing.T) {
 func TestAccServiceInstanceLifeCycle_typeDatagrid(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
-	// siClient, dClient, err := getServiceInstanceTestClients()
-	siClient, _, err := getServiceInstanceTestClients()
-
+	siClient, dClient, err := getServiceInstanceTestClients()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	/*
-		databaseParameter := database.ParameterInput{
-			AdminPassword:                   _ServiceInstanceDBAPassword,
-			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
-			SID:                             _ServiceInstanceDBSID,
-			Type:                            _ServiceInstanceDBType,
-			UsableStorage:                   _ServiceInstanceUsableStorage,
-			CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
-			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
-		}
+	databaseParameter := database.ParameterInput{
+		AdminPassword:                   _ServiceInstanceDBAPassword,
+		BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+		SID:                             _ServiceInstanceDBSID,
+		Type:                            _ServiceInstanceDBType,
+		UsableStorage:                   _ServiceInstanceUsableStorage,
+		CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+	}
 
-		createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
-			Name:             _ServiceInstanceDatabaseName,
-			Edition:          _ServiceInstanceEdition,
-			Level:            _ServiceInstanceLevel,
-			Shape:            _ServiceInstanceShape,
-			SubscriptionType: _ServiceInstanceSubscriptionType,
-			Version:          _ServiceInstanceDBVersion,
-			VMPublicKey:      _ServiceInstancePubKey,
-			Parameter:        databaseParameter,
-		}
+	createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
+		Name:             _ServiceInstanceDatabaseName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscriptionType,
+		Version:          _ServiceInstanceDBVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        databaseParameter,
+	}
 
-		_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName) */
-
-	/*
-		scalingUnit := ScalingUnit{
-			Shape:    "oc3",
-			VMCount:  1,
-			HeapSize: "4G",
-			JVMCount: 2,
-		} */
+	_, err = dClient.CreateServiceInstance(createDatabaseServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyDatabaseServiceInstance(t, dClient, _ServiceInstanceDatabaseName)
 
 	datagridParameter := Parameter{
 		Type:             ServiceInstanceTypeDataGrid,
 		ScalingUnitCount: 1,
 		ClusterName:      "testDataGrid",
 		ScalingUnitName:  "SMALL",
-		// ScalingUnits:     []ScalingUnit{scalingUnit},
 	}
 
 	webLogicParameter := Parameter{
@@ -261,7 +246,7 @@ func TestAccServiceInstanceLifeCycle_typeDatagrid(t *testing.T) {
 		Edition:       ServiceInstanceEditionSuite,
 		DBAName:       _ServiceInstanceDBAUser,
 		DBAPassword:   _ServiceInstanceDBAPassword,
-		DBServiceName: "test-service-instance-matthew",
+		DBServiceName: _ServiceInstanceDatabaseName,
 		Shape:         _ServiceInstanceShape,
 		Version:       _ServiceInstanceVersion,
 		AdminUsername: _ServiceInstanceAdminUsername,


### PR DESCRIPTION
This PR adds extra tests to go-oracle-terraform and fixes code to make them work.

```
make testacc TEST=./java TESTARGS="-run=TestAccServiceInstance"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./java -run=TestAccServiceInstance -timeout 120m
=== RUN   TestAccServiceInstanceLifeCycle
--- PASS: TestAccServiceInstanceLifeCycle (4619.20s)
=== RUN   TestAccServiceInstanceLifeCycle_typeOTD
--- PASS: TestAccServiceInstanceLifeCycle_typeOTD (4585.08s)
=== RUN   TestAccServiceInstanceLifeCycle_typeDatagrid
--- PASS: TestAccServiceInstanceLifeCycle_typeDatagrid (3027.95s)
PASS
```