### PR TITLE
Add attribute for is_default_gateway

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -252,6 +252,10 @@ type NetworkingInfo struct {
 	// Required
 	IPNetwork string `json:"ipnetwork,omitempty"`
 	// IP Network only.
+	// Set interface as default gateway for all traffic
+	// Optional
+	IsDefaultGateway bool `json:"is_default_gateway,omitempty"`
+	// IP Network only.
 	// The hexadecimal MAC Address of the interface
 	// Optional
 	MACAddress string `json:"address,omitempty"`


### PR DESCRIPTION
Add the `is_default_gateway` attribute used to designate the default gateway interface for IP Network interfaces