### PR TITLE
Adding UserAgent to client

### DIFF
--- a/client/version.go
+++ b/client/version.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	major = 0
+	minor = 6
+	patch = 1
+	tag   = ""
+)
+
+var once sync.Once
+var version string
+
+// Version returns the semantic version (see http://semver.org).
+func Version() string {
+	once.Do(func() {
+		semver := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+		verBuilder := bytes.NewBufferString(semver)
+		if tag != "" && tag != "-" {
+			updated := strings.TrimPrefix(tag, "-")
+			_, err := verBuilder.WriteString("-" + updated)
+			if err == nil {
+				verBuilder = bytes.NewBufferString(semver)
+			}
+		}
+		version = verBuilder.String()
+	})
+	return version
+}

--- a/java/java_client.go
+++ b/java/java_client.go
@@ -32,7 +32,7 @@ func NewJavaClient(c *opc.Config) (*JavaClient, error) {
 }
 
 func (c *JavaClient) executeRequest(method, path string, body interface{}) (*http.Response, error) {
-	req, err := c.client.BuildRequest(method, path, body)
+	req, err := c.client.BuildRequestBody(method, path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/opc/config.go
+++ b/opc/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	LogLevel       LogLevelType
 	Logger         Logger
 	HTTPClient     *http.Client
+	UserAgent      *string
 }
 
 func NewConfig() *Config {


### PR DESCRIPTION
Adding UserAgent to the client and removing a deprecated method

```
make testacc TEST=./client TESTARGS="-run=TestClient_userAgent"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./client -run=TestClient_userAgent -timeout 120m
=== RUN   TestClient_userAgent
--- PASS: TestClient_userAgent (0.00s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/client	0.011s```