### PR TITLE
Add suspend test

### DIFF
--- a/compute/orchestration.go
+++ b/compute/orchestration.go
@@ -51,6 +51,7 @@ const (
 	OrchestrationStatusSuspending   OrchestrationStatus = "suspending"
 	OrchestrationStatusStarting     OrchestrationStatus = "starting"
 	OrchestrationStatusDeactivating OrchestrationStatus = "deactivating"
+	OrchestrationStatusSuspended    OrchestrationStatus = "suspended"
 )
 
 type OrchestrationType string
@@ -385,6 +386,13 @@ func (c *OrchestrationsClient) WaitForOrchestrationState(input *GetOrchestration
 		case OrchestrationStatusDeactivating:
 			c.client.DebugLogString("Orchestration deactivating")
 			return false, nil
+		case OrchestrationStatusSuspended:
+			c.client.DebugLogString("Orchestration suspended")
+			if info.DesiredState == OrchestrationDesiredStateSuspend {
+				return true, nil
+			} else {
+				return false, nil
+			}
 		default:
 			return false, fmt.Errorf("Unknown orchestration state: %s, erroring", s)
 		}


### PR DESCRIPTION
Adding a test to make sure suspending an orchestration works properly

```
OPC_LOG=1 make testacc TEST=./compute TESTARGS="-run=TestAccOrchestrationLifeCycle_suspend"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./compute -run=TestAccOrchestrationLifeCycle_suspend -timeout 120m
=== RUN   TestAccOrchestrationLifeCycle_suspend
--- PASS: TestAccOrchestrationLifeCycle_suspend (148.32s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/compute	148.344s
```