### PR TITLE
add option to delete snapshot resource only, and not machine image.

### DIFF
--- a/compute/snapshots.go
+++ b/compute/snapshots.go
@@ -176,6 +176,31 @@ func (c *SnapshotsClient) DeleteSnapshot(machineImagesClient *MachineImagesClien
 	return nil
 }
 
+// DeleteSnapshotResourceOnly deletes the Snapshot with the given name.
+// The machine image that gets created with the associated snapshot is not
+// deleted by this method.
+func (c *SnapshotsClient) DeleteSnapshotResourceOnly(input *DeleteSnapshotInput) error {
+	// Wait for snapshot complete in case delay is active and the corresponding
+	// instance needs to be deleted first
+	getInput := &GetSnapshotInput{
+		Name: input.Snapshot,
+	}
+
+	if input.Timeout == 0 {
+		input.Timeout = WaitForSnapshotCompleteTimeout
+	}
+
+	if _, err := c.WaitForSnapshotComplete(getInput, input.Timeout); err != nil {
+		return fmt.Errorf("Could not delete snapshot: %s", err)
+	}
+
+	if err := c.deleteResource(input.Snapshot); err != nil {
+		return fmt.Errorf("Could not delete snapshot: %s", err)
+	}
+
+	return nil
+}
+
 // WaitForSnapshotComplete waits for an snapshot to be completely initialized and available.
 func (c *SnapshotsClient) WaitForSnapshotComplete(input *GetSnapshotInput, timeout time.Duration) (*Snapshot, error) {
 	var info *Snapshot


### PR DESCRIPTION
I need to be able to delete a snapshot resource but not the associated machine image in the Packer Oracle Builder -- https://github.com/hashicorp/packer/pull/5819