### PR TITLE
Adding java access rules

### DIFF
--- a/database/access_rules.go
+++ b/database/access_rules.go
@@ -272,7 +272,6 @@ func (c *UtilityClient) DeleteAccessRule(input *DeleteAccessRuleInput) error {
 		return err
 	}
 
-
 	timeout := input.Timeout
 	if timeout == 0 {
 		timeout = WaitForAccessRuleTimeout

--- a/java/access_rules.go
+++ b/java/access_rules.go
@@ -88,6 +88,8 @@ type AccessRuleInfo struct {
 	Destination AccessRuleDestination `json:"destination"`
 	// The ports for the rule.
 	Ports string `json:"ports"`
+	// Protocol for the rule. One of: "tcp" or "udp"
+	Protocol AccessRuleProtocol `json:"protocol"`
 	// The name of the Access Rule
 	Name string `json:"ruleName"`
 	// The Type of the rule. One of: "DEFAULT", "SYSTEM", or "USER".

--- a/java/access_rules.go
+++ b/java/access_rules.go
@@ -1,0 +1,340 @@
+// Manages Access Rules for a JaaS Service Instance.
+// The only fields that can be Updated for an Access Rule is the desired state
+// of the access rule. From Enabled -> Disabled.
+// Deleting an Access Rule also requires an Update call, instead of a Delete API request,
+// but the Operation body parameter changes from `update` to `delete`.
+// All other parameters for the resource, aside from Status should be ForceNew.
+// The READ function for the AccessRule resource is tricky, as there is
+// no exposed `GET` function on the AccessRule API.
+// There is an API endpoint to view "all" rules, however, which will be used as a
+// data source to match on a supplied AccessRule name.
+// Timeout only supported for the CREATE method
+
+package java
+
+import "time"
+
+// API URI Paths for Container and Root objects
+const (
+	JAccessContainerPath = "/paas/api/v1.1/instancemgmt/%s/services/jaas/instances/%s/accessrules"
+	JAccessRootPath      = "/paas/api/v1.1/instancemgmt/%s/services/jaas/instances/%s/accessrules/%s"
+)
+
+// Default Timeout value for Create
+const WaitForAccessRuleTimeout = time.Duration(10 * time.Second)
+
+// AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a DBaaS Service Instance
+func (c *JavaClient) AccessRules() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			JavaClient:       c,
+			ContainerPath:    JAccessContainerPath,
+			ResourceRootPath: JAccessRootPath,
+		},
+	}
+}
+
+// Status Constants for an Access Rule
+type AccessRuleStatus string
+
+const (
+	AccessRuleEnabled  AccessRuleStatus = "enabled"
+	AccessRuleDisabled AccessRuleStatus = "disabled"
+)
+
+// Operational Constants for either Updating/Deleting an Access Rule
+type AccessRuleOperation string
+
+const (
+	AccessRuleUpdate AccessRuleOperation = "update"
+	AccessRuleDelete AccessRuleOperation = "delete"
+)
+
+// Default Destination for an Access Rule
+type AccessRuleDestination string
+
+const (
+	AccessRuleDestinationWLSAdmin       AccessRuleDestination = "WLS_ADMIN"
+	AccessRuleDestinationWLSAdminServer AccessRuleDestination = "WLS_ADMIN_SERVER"
+	AccessRuleDestinationOTD            AccessRuleDestination = "OTD"
+	AccessRuleDestinationOTDAdminHost   AccessRuleDestination = "OTD_ADMIN_HOST"
+)
+
+// Used for the GET request, as there's no direct GET request for a single Access Rule
+type AccessRules struct {
+	Rules []AccessRuleInfo `json:"accessRules"`
+}
+
+type AccessRuleType string
+
+const (
+	AccessRuleTypeDefault AccessRuleType = "DEFAULT"
+	AccessRuleTypeSystem  AccessRuleType = "SYSTEM"
+	AccessRuleTypeUser    AccessRuleType = "USER"
+)
+
+type AccessRuleProtocol string
+
+const (
+	AccessRuleProtocolTCP AccessRuleProtocol = "tcp"
+	AccessRuleProtocolUDP AccessRuleProtocol = "udp"
+)
+
+// AccessRuleInfo holds all of the known information for a single AccessRule
+type AccessRuleInfo struct {
+	// The Description of the Access Rule
+	Description string `json:"description"`
+	// The destination of the Access Rule. Should always be "DB".
+	Destination AccessRuleDestination `json:"destination"`
+	// The ports for the rule.
+	Ports string `json:"ports"`
+	// The name of the Access Rule
+	Name string `json:"ruleName"`
+	// The Type of the rule. One of: "DEFAULT", "SYSTEM", or "USER".
+	// Computed Value
+	RuleType AccessRuleType `json:"ruleType"`
+	// The IP Addresses and subnets from which traffic is allowed
+	Source string `json:"source"`
+	// The current status of the Access Rule
+	Status AccessRuleStatus `json:"status"`
+}
+
+// CreateAccessRuleInput defines the input parameters needed to create an Access Rule for a DBaaS Service Instance.
+type CreateAccessRuleInput struct {
+	// Name of the JaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Description of the Access Rule.
+	// Required
+	Description string `json:"description"`
+	// Destination to which traffic is allowed. Specify the value "DB".
+	// Required
+	Destination AccessRuleDestination `json:"destination"`
+	// The network port or ports to allow traffic on. Specified as a single port or a range.
+	// Required
+	Ports string `json:"ports"`
+	// Communication protocol. Valid values are: tcp or udp.
+	// Default is tcp.
+	// Optional
+	Protocol AccessRuleProtocol `json:"protocol"`
+	// The name of the Access Rule
+	// Required
+	Name string `json:"ruleName"`
+	// The IP addresses and subnets from which traffic is allowed.
+	// Valid values are:
+	//   - A service component name. Valid values include WLS_ADMIN or WLS_ADMIN_SERVER, WLS_MS or WLS_MANAGED_SERVER, OTD_ADMIN_HOST or OTD, DBaaS:Your_DBCS_Name:DB or DB
+	//   - "PUBLIC-INTERNET" for any host on the internet.
+	//   - A single IP address or comma-separated list of subnets (in CIDR format) or IPv4 addresses.
+	// Required
+	Source string `json:"source"`
+	// Desired Status of the rule. Either "disabled" or "enabled".
+	// Required
+	Status AccessRuleStatus `json:"status"`
+	// Time to wait for an access rule to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Creates an AccessRule with the supplied input struct.
+// The API call to Create returns a nil body object, and a 202 status code on success.
+// Thus, the Create method will return the resulting object from an internal GET call
+// during the WaitForReady timeout.
+func (c *UtilityClient) CreateAccessRule(input *CreateAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRule AccessRuleInfo
+	if err := c.createResource(input, &accessRule); err != nil {
+		return nil, err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForAccessRuleTimeout
+	}
+
+	getInput := &GetAccessRuleInput{
+		Name: input.Name,
+	}
+
+	result, err := c.WaitForAccessRuleReady(getInput, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAccessRuleInput defines the input parameters needed to retrieve information
+// on an AccessRule for a DBaas Service Instance.
+type GetAccessRuleInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule.
+	// Because there is no native "GET" to return a single AccessRuleInfo object, we don't
+	// need to marshal a request body for the GET request. Instead the request returns a slice
+	// of AccessRuleInfo structs, which we iterate on to interpret the desired AccessRuleInfo struct
+	// Required
+	Name string `json:"-"`
+}
+
+// Get's a slice of every AccessRule, and iterates on the result until
+// we find the correctly matching access rule. This is likely an expensive operation depending
+// on how many access rules the customer has. However, since there's no direct GET API endpoint
+// for a single Access Rule, it's not able to be optimized yet.
+func (c *UtilityClient) GetAccessRule(input *GetAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRules AccessRules
+	if err := c.getResource("", &accessRules); err != nil {
+		return nil, err
+	}
+
+	// This is likely not the most optimal path for this, however, the upper bound on
+	// performance here is the actual API request, not the iteration.
+	for _, rule := range accessRules.Rules {
+		if rule.Name == input.Name {
+			return &rule, nil
+		}
+	}
+
+	// Iterated through entire slice, rule was not found.
+	// No error occured though, return a nil struct, and allow the Provdier to handle
+	// a Nil response case.
+	return nil, nil
+}
+
+// UpdateAccessRuleInput defines the Update parameters needed to update an AccessRule
+// for a DBaaS Service Instance.
+type UpdateAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Update function here, so the SDK uses the constant
+	// defined for Updating an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+}
+
+// Updates an AccessRule with the provided input struct. Returns a fully populated Info struct
+// and any errors encountered
+func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput,
+) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleUpdate
+	// Initialize the response struct
+	var accessRule AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &accessRule); err != nil {
+		return nil, err
+	}
+	return &accessRule, nil
+}
+
+// DeleteAccessRuleInput defines the Delete parameters needed to delete an AccessRule
+// for a DBaaS Service Instance. There's no dedicated DELETE method on the API, so this
+// mimics the same behavior of the Update method, but using the Delete operational constant.
+// Instead of implementing, choosing to be verbose here for ease of use in the Provider, and clarity.
+type DeleteAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Delete function here, so the SDK uses the constant
+	// defined for Deleting an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+	// Time to wait for an access rule to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Deletes an AccessRule with the provided input struct. Returns any errors that occurred.
+func (c *UtilityClient) DeleteAccessRule(input *DeleteAccessRuleInput) error {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleDelete
+	// The Update API call with a `DELETE` operation actually returns the same access rule info
+	// in a response body. As we are deleting the AccessRule, we don't actually need to parse that.
+	// However, the Update API call requires a pointer to parse, or else we throw an error during the
+	// json unmarshal
+	var result AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &result); err != nil {
+		return err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForAccessRuleTimeout
+	}
+
+	getInput := &GetAccessRuleInput{
+		Name: input.Name,
+	}
+
+	_, err := c.WaitForAccessRuleDeleted(getInput, timeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UtilityClient) WaitForAccessRuleReady(input *GetAccessRuleInput, timeout time.Duration) (*AccessRuleInfo, error) {
+	var info *AccessRuleInfo
+	var getErr error
+	err := c.client.WaitFor("access rule to be ready", timeout, func() (bool, error) {
+		info, getErr = c.GetAccessRule(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		if info != nil {
+			// Rule found, return. Desired case
+			return true, nil
+		}
+		// Rule not found, wait
+		return false, nil
+	})
+	return info, err
+}
+
+func (c *UtilityClient) WaitForAccessRuleDeleted(input *GetAccessRuleInput, timeout time.Duration) (*AccessRuleInfo, error) {
+	var info *AccessRuleInfo
+	var getErr error
+	err := c.client.WaitFor("access rule to be deleted", timeout, func() (bool, error) {
+		info, getErr = c.GetAccessRule(input)
+		if getErr != nil {
+			return true, nil
+		}
+		if info != nil {
+			// Rule found, continue
+			return false, nil
+		}
+		// Rule not found, return. Desired case
+		return true, nil
+	})
+	return info, err
+}

--- a/java/access_rules.go
+++ b/java/access_rules.go
@@ -23,7 +23,7 @@ const (
 // Default Timeout value for Create
 const WaitForAccessRuleTimeout = time.Duration(10 * time.Second)
 
-// AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a DBaaS Service Instance
+// AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a JaaS Service Instance
 func (c *JavaClient) AccessRules() *UtilityClient {
 	return &UtilityClient{
 		UtilityResourceClient: UtilityResourceClient{
@@ -84,7 +84,7 @@ const (
 type AccessRuleInfo struct {
 	// The Description of the Access Rule
 	Description string `json:"description"`
-	// The destination of the Access Rule. Should always be "DB".
+	// The destination of the Access Rule
 	Destination AccessRuleDestination `json:"destination"`
 	// The ports for the rule.
 	Ports string `json:"ports"`
@@ -99,7 +99,7 @@ type AccessRuleInfo struct {
 	Status AccessRuleStatus `json:"status"`
 }
 
-// CreateAccessRuleInput defines the input parameters needed to create an Access Rule for a DBaaS Service Instance.
+// CreateAccessRuleInput defines the input parameters needed to create an Access Rule for a JaaS Service Instance.
 type CreateAccessRuleInput struct {
 	// Name of the JaaS service instance.
 	// Required
@@ -107,7 +107,7 @@ type CreateAccessRuleInput struct {
 	// Description of the Access Rule.
 	// Required
 	Description string `json:"description"`
-	// Destination to which traffic is allowed. Specify the value "DB".
+	// Destination to which traffic is allowed.
 	// Required
 	Destination AccessRuleDestination `json:"destination"`
 	// The network port or ports to allow traffic on. Specified as a single port or a range.
@@ -166,9 +166,9 @@ func (c *UtilityClient) CreateAccessRule(input *CreateAccessRuleInput) (*AccessR
 }
 
 // GetAccessRuleInput defines the input parameters needed to retrieve information
-// on an AccessRule for a DBaas Service Instance.
+// on an AccessRule for a Jaas Service Instance.
 type GetAccessRuleInput struct {
-	// Name of the DBaaS service instance.
+	// Name of the JaaS service instance.
 	// Required
 	ServiceInstanceID string `json:"-"`
 	// Name of the Access Rule.
@@ -208,9 +208,9 @@ func (c *UtilityClient) GetAccessRule(input *GetAccessRuleInput) (*AccessRuleInf
 }
 
 // UpdateAccessRuleInput defines the Update parameters needed to update an AccessRule
-// for a DBaaS Service Instance.
+// for a JaaS Service Instance.
 type UpdateAccessRuleInput struct {
-	// Name of the DBaaS Service Instance.
+	// Name of the JaaS Service Instance.
 	// Required
 	ServiceInstanceID string `json:"-"`
 	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
@@ -246,11 +246,11 @@ func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput,
 }
 
 // DeleteAccessRuleInput defines the Delete parameters needed to delete an AccessRule
-// for a DBaaS Service Instance. There's no dedicated DELETE method on the API, so this
+// for a JaaS Service Instance. There's no dedicated DELETE method on the API, so this
 // mimics the same behavior of the Update method, but using the Delete operational constant.
 // Instead of implementing, choosing to be verbose here for ease of use in the Provider, and clarity.
 type DeleteAccessRuleInput struct {
-	// Name of the DBaaS Service Instance.
+	// Name of the JaaS Service Instance.
 	// Required
 	ServiceInstanceID string `json:"-"`
 	// Name of the Access Rule. Used in the request's URI, not as a body parameter.

--- a/java/access_rules_test.go
+++ b/java/access_rules_test.go
@@ -97,6 +97,7 @@ func TestAccAccessRulesLifeCycle(t *testing.T) {
 		Description: _TestAccessRuleDescription,
 		Destination: AccessRuleDestinationWLSAdmin,
 		Ports:       _TestAccessRulePorts,
+		Protocol:    AccessRuleProtocolTCP,
 		Name:        _TestAccessRuleName,
 		Source:      _TestAccessRuleSource,
 		Status:      AccessRuleDisabled,

--- a/java/access_rules_test.go
+++ b/java/access_rules_test.go
@@ -1,0 +1,176 @@
+package java
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/database"
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+// Testing Parameters Used
+const (
+	_TestAccessRuleDescription = "testing description"
+	_TestAccessRulePorts       = "7000-8000"
+	_TestAccessRuleSource      = "PUBLIC-INTERNET"
+)
+
+var _TestAccessRuleName = fmt.Sprintf("test-acc-rule-%d", helper.RInt())
+
+func TestAccAccessRulesLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	sClient, dbClient, aClient, err := getAccessRulesTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	databaseParameter := database.ParameterInput{
+		AdminPassword:                   _ServiceInstanceDBAPassword,
+		BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+		SID:                             _ServiceInstanceDBSID,
+		Type:                            _ServiceInstanceDBType,
+		UsableStorage:                   _ServiceInstanceUsableStorage,
+		CloudStorageContainer:           _ServiceInstanceDBCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+	}
+
+	createDatabaseServiceInstance := &database.CreateServiceInstanceInput{
+		Name:             _ServiceInstanceDatabaseName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceDatabaseShape,
+		SubscriptionType: _ServiceInstanceSubscriptionType,
+		Version:          _ServiceInstanceDBVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        databaseParameter,
+	}
+
+	_, err = dbClient.CreateServiceInstance(createDatabaseServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyDatabaseServiceInstance(t, dbClient, _ServiceInstanceDatabaseName)
+
+	wlsConfig := &CreateWLS{
+		DBAName:            _ServiceInstanceDBAUser,
+		DBAPassword:        _ServiceInstanceDBAPassword,
+		DBServiceName:      _ServiceInstanceDatabaseName,
+		Shape:              _ServiceInstanceShape,
+		ManagedServerCount: _ServiceInstanceManagedServerCount,
+		AdminUsername:      _ServiceInstanceAdminUsername,
+		AdminPassword:      _ServiceInstanceAdminPassword,
+	}
+
+	createServiceInstance := &CreateServiceInstanceInput{
+		CloudStorageContainer:             _ServiceInstanceCloudStorageContainer,
+		CloudStorageContainerAutoGenerate: _ServiceInstanceCloudStorageCreateIfMissing,
+		ServiceName:                       _ServiceInstanceName,
+		ServiceLevel:                      _ServiceInstanceLevel,
+		Components:                        CreateComponents{WLS: wlsConfig},
+		VMPublicKeyText:                   _ServiceInstancePubKey,
+		Edition:                           ServiceInstanceEditionSuite,
+		ServiceVersion:                    _ServiceInstanceVersion,
+	}
+
+	_, err = sClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyServiceInstance(t, sClient, _ServiceInstanceName)
+
+	// Create an Access Rule that's disabled
+	input := &CreateAccessRuleInput{
+		ServiceInstanceID: _ServiceInstanceName,
+		Description:       _TestAccessRuleDescription,
+		Destination:       AccessRuleDestinationWLSAdmin,
+		Protocol:          AccessRuleProtocolTCP,
+		Ports:             _TestAccessRulePorts,
+		Name:              _TestAccessRuleName,
+		Source:            _TestAccessRuleSource,
+		Status:            AccessRuleDisabled,
+	}
+
+	expected := &AccessRuleInfo{
+		Description: _TestAccessRuleDescription,
+		Destination: AccessRuleDestinationWLSAdmin,
+		Ports:       _TestAccessRulePorts,
+		Name:        _TestAccessRuleName,
+		Source:      _TestAccessRuleSource,
+		Status:      AccessRuleDisabled,
+		RuleType:    AccessRuleTypeUser,
+	}
+
+	// Create Access Rule
+	if _, err := aClient.CreateAccessRule(input); err != nil {
+		t.Fatalf("Error creating AccessRule: %s", err)
+	}
+	defer destroyAccessRule(t, aClient, _ServiceInstanceName, _TestAccessRuleName)
+
+	// Get Access Rule (Create only returns AccessRule name)
+	getInput := &GetAccessRuleInput{
+		ServiceInstanceID: _ServiceInstanceName,
+		Name:              _TestAccessRuleName,
+	}
+
+	// Read Result
+	result, err := aClient.GetAccessRule(getInput)
+	if err != nil {
+		t.Fatalf("Error reading AccessRule: %s", err)
+	}
+
+	// Test Assertions
+	if diff := pretty.Compare(result, expected); diff != "" {
+		t.Fatalf("Diff creating AccessRule: (-got, +want):\n%s", diff)
+	}
+
+	// Update Access Rule
+	updateInput := &UpdateAccessRuleInput{
+		ServiceInstanceID: _ServiceInstanceName,
+		Name:              _TestAccessRuleName,
+		Status:            AccessRuleEnabled,
+	}
+
+	if _, err := aClient.UpdateAccessRule(updateInput); err != nil {
+		t.Fatalf("Error updating AccessRule: %s", err)
+	}
+
+	// Re-Read Result
+	result, err = aClient.GetAccessRule(getInput)
+	if err != nil {
+		t.Fatalf("Error reading AccessRule: %s", err)
+	}
+
+	// Change expected to match
+	expected.Status = AccessRuleEnabled
+
+	// Test Assertions
+	if diff := pretty.Compare(result, expected); diff != "" {
+		t.Fatalf("Diff creating AccessRule: (-got, +want):\n%s", diff)
+	}
+}
+
+func getAccessRulesTestClients() (*ServiceInstanceClient, *database.ServiceInstanceClient, *UtilityClient, error) {
+	dbClient, err := database.GetDatabaseTestClient(&opc.Config{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	client, err := getJavaTestClient(&opc.Config{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return client.ServiceInstanceClient(), dbClient.ServiceInstanceClient(), client.AccessRules(), nil
+}
+
+func destroyAccessRule(t *testing.T, client *UtilityClient, serviceInstance, name string) {
+	input := &DeleteAccessRuleInput{
+		Name:              name,
+		ServiceInstanceID: serviceInstance,
+	}
+	if err := client.DeleteAccessRule(input); err != nil {
+		t.Fatalf("Error deleting Access Rule: %s", err)
+	}
+}

--- a/java/java_client.go
+++ b/java/java_client.go
@@ -44,7 +44,7 @@ func (c *JavaClient) executeRequest(method, path string, body interface{}) (*htt
 
 	debugReqString := fmt.Sprintf("HTTP %s Path (%s)", method, path)
 	if body != nil {
-		req.Header.Set("Content-Type", "application/vnd.com.oracle.oracloud.provisioning.Service+json")
+		req.Header.Set("Content-Type", "application/json")
 	}
 	// Log the request before the authentication header, so as not to leak credentials
 	c.client.DebugLogString(debugReqString)

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -901,7 +901,7 @@ type CreateOTD struct {
 	// Policy to use for routing requests to the load balancer. Valid policies include:
 	// Optional.
 	LoadBalancingPolicy ServiceInstanceLoadBalancingPolicy `json:"loadBalancingPolicy,omitempty"`
-	//Privileged listener port for accessing the deployed applications using HTTP. The default value is 80.
+	// Privileged listener port for accessing the deployed applications using HTTP. The default value is 80.
 	// This value has no effect if the local load balancer is disabled.
 	// To disable the privileged listener port, set the value to 0. In this case, if the local
 	// load balancer is provisioned, the listener port defaults to listenerPort, if specified, or 8080.

--- a/java/utility_resource_client.go
+++ b/java/utility_resource_client.go
@@ -1,0 +1,114 @@
+package java
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// The UtilityClient which extends the UtilityResourceClient.
+// This is purely because utility resources (SSH Keys + Access Rules) include the service
+// instance name in the URL path for managing these resources, so we cannot use the same
+// resource client that the service instance uses. We're still using the same OPC client, just
+// abstracting the path helper functions to make life a little easier.
+type UtilityClient struct {
+	UtilityResourceClient
+}
+
+// UtilityResourceClient is a client to manage resources on an already created service instance
+type UtilityResourceClient struct {
+	*JavaClient
+	ContainerPath     string
+	ResourceRootPath  string
+	ServiceInstanceID string
+}
+
+func (c *UtilityResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UtilityResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
+	resp, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.getContainerPath(c.ContainerPath)
+	}
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) deleteResource(name string, body interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	_, err := c.executeRequest("DELETE", objectPath, body)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}
+
+func (c *UtilityResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err := dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("Error decoding: %s\n%+v", err.Error(), resp)
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UtilityResourceClient) getContainerPath(root string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/jaas/instances/{serviceId}/accessrules
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID)
+}
+
+func (c *UtilityResourceClient) getObjectPath(root, name string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/jaas/instances/{serviceId}/accessrules/{ruleName}
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID, name)
+}


### PR DESCRIPTION
This PR adds Java Access Rules to the go-sdk

```
make testacc TEST=./java TESTARGS="-run=TestAccAccessRulesLifeCycle"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./java -run=TestAccAccessRulesLifeCycle -timeout 120m
=== RUN   TestAccAccessRulesLifeCycle
--- PASS: TestAccAccessRulesLifeCycle 
PASS
ok  	github.com/hashicorp/go-oracle-terraform/java	
```