### PR TITLE
Fix debug log

### DIFF
--- a/database/database_client.go
+++ b/database/database_client.go
@@ -49,7 +49,7 @@ func (c *DatabaseClient) executeRequest(method, path string, body interface{}) (
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 		// Debug the body for database services
-		debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, string(reqBody))
+		debugReqString = fmt.Sprintf("%s:\nBody: %+v", debugReqString, string(reqBody))
 	}
 	// Log the request before the authentication header, so as not to leak credentials
 	c.client.DebugLogString(debugReqString)

--- a/java/java_client.go
+++ b/java/java_client.go
@@ -45,10 +45,11 @@ func (c *JavaClient) executeRequest(method, path string, body interface{}) (*htt
 	debugReqString := fmt.Sprintf("HTTP %s Path (%s)", method, path)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+		// Output the request body json
+		debugReqString = fmt.Sprintf("%s:\nBody: %+v", debugReqString, string(reqBody))
 	}
 	// Log the request before the authentication header, so as not to leak credentials
 	c.client.DebugLogString(debugReqString)
-	c.client.DebugLogString(fmt.Sprintf("Req (%+v)", req))
 
 	// Set the authentiation headers
 	req.Header.Add(AUTH_HEADER, *c.authHeader)


### PR DESCRIPTION
Small fix for an odd bug - I noticed the database JSON request payloads weren't appearing in the debug logs, adding an extra character after \n in the Sprintf fixes it!?

Also made the Java client debug output consistent.