### PR TITLE
Consistent use of Image List in Acceptance tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ func main() {
     Name: "test-instance",
     Label: "test",
     Shape: "oc3",
-    ImageList: "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+    ImageList: "/oracle/public/OL_7.2_UEKR4_x86_64",
     Storage: nil,
     BootOrder: nil,
     SSHKeys: []string{},

--- a/compute/image_list_entries_test.go
+++ b/compute/image_list_entries_test.go
@@ -39,8 +39,8 @@ func TestAccImageListEntriesLifeCycle(t *testing.T) {
 
 	createInput := &CreateImageListEntryInput{
 		Name:          _ImageListEntryTestName,
-		MachineImages: []string{"/oracle/public/oel_6.7_apaas_16.4.5_1610211300"},
-		Version:       _ImageListEntryTestVersion,
+		MachineImages: []string{"/oracle/public/OL_7.2_UEKR4_x86_64-18.1.4-20180209-231028"},
+		Version:       1,
 	}
 
 	createdImageListEntry, err := entryClient.CreateImageListEntry(createInput)

--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -230,7 +230,7 @@ var exampleCreateResponse = `
       "cluster": null,
       "shape": "oc3",
       "vethernets": null,
-      "imagelist": "/oracle/public/oel_6.4_2GB_v1",
+      "imagelist": "/oracle/public/OL_7.2_UEKR4_x86_64",
       "image_format": "raw",
       "id": "016e75e7-e911-42d1-bfe1-6a7f1b3f7908",
       "cluster_uri": null,
@@ -310,7 +310,7 @@ var exampleRetrieveResponse = `
 "ip": "10...",
 "site": "",
 "shape": "oc5",
-"imagelist": "/oracle/public/oel_6.4_60GB",
+"imagelist": "/oracle/public/OL_7.2_UEKR4_x86_64",
 "attributes": {
 "network": {
 "nimbula_vcable-eth0": {
@@ -394,7 +394,7 @@ var exampleErrorRetrieveResponse = `
 "ip": "10...",
 "site": "",
 "shape": "oc5",
-"imagelist": "/oracle/public/oel_6.4_60GB",
+"imagelist": "/oracle/public/OL_7.2_UEKR4_x86_64",
 "attributes": {
 "network": {
 "nimbula_vcable-eth0": {

--- a/compute/ip_associations_test.go
+++ b/compute/ip_associations_test.go
@@ -12,7 +12,7 @@ func TestAccIPAssociationLifeCycle(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 	var (
 		parentPool    string = "ippool:/oracle/public/ippool"
-		instanceImage string = "/oracle/public/oel_6.7_apaas_16.4.5_1610211300"
+		instanceImage string = "/oracle/public/OL_7.2_UEKR4_x86_64"
 	)
 
 	iClient, ipaClient, err := getIPAssociationsTestClients()

--- a/compute/orchestration_test.go
+++ b/compute/orchestration_test.go
@@ -15,8 +15,8 @@ const (
 	_OrchestrationTestLabel            = "test-acc-orchestration-lbl"
 	_OrchestrationInstanceTestLabel    = "test"
 	_OrchestrationInstanceTestShape    = "oc3"
-	_OrchestrationInstanceTestImage    = "/oracle/public/Oracle_Solaris_11.3"
-	_OrchestrationInstanceTestBadImage = "/oracle/public/Oracle_Solaris_11.3_bad"
+	_OrchestrationInstanceTestImage    = "/oracle/public/OL_7.2_UEKR4_x86_64"
+	_OrchestrationInstanceTestBadImage = "/oracle/public/OL_7.2_UEKR4_x86_64_bad"
 )
 
 func TestAccOrchestrationLifeCycle(t *testing.T) {

--- a/compute/security_associations_test.go
+++ b/compute/security_associations_test.go
@@ -14,7 +14,7 @@ func TestAccSecurityAssociationLifeCycle(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
 	var (
-		instanceImage string = "/oracle/public/oel_6.7_apaas_16.4.5_1610211300"
+		instanceImage string = "/oracle/public/OL_7.2_UEKR4_x86_64"
 		name          string = "test-sec-association"
 	)
 

--- a/compute/snapshots_test.go
+++ b/compute/snapshots_test.go
@@ -15,7 +15,7 @@ const (
 	_SnapshotInstanceTestName    = "test-acc-snapshot"
 	_SnapshotInstanceTestLabel   = "test"
 	_SnapshotInstanceTestShape   = "oc3"
-	_SnapshotInstanceTestImage   = "/oracle/public/JEOS_OL_6.6_10GB_RD-1.2.217-20151201-194209"
+	_SnapshotInstanceTestImage   = "/oracle/public/OL_7.2_UEKR4_x86_64"
 	_SnapshotInstanceTestAccount = "cloud_storage"
 )
 

--- a/compute/storage_volume_attachments_integration_test.go
+++ b/compute/storage_volume_attachments_integration_test.go
@@ -27,7 +27,7 @@ func TestAccStorageAttachmentsLifecycle(t *testing.T) {
 		Name:      instanceName,
 		Label:     "test-acc-stor-acc-lifecycle",
 		Shape:     "oc3",
-		ImageList: "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+		ImageList: "/oracle/public/OL_7.2_UEKR4_x86_64",
 		Storage:   nil,
 		BootOrder: nil,
 		SSHKeys:   []string{},

--- a/compute/storage_volumes_integration_test.go
+++ b/compute/storage_volumes_integration_test.go
@@ -39,40 +39,7 @@ func TestAccStorageVolumeBootableLifecycle(t *testing.T) {
 	rInt := rand.Int()
 	name := fmt.Sprintf("test-acc-storage-volume-bootable-lifecycle-%d", rInt)
 
-	imageListName := fmt.Sprintf("test-acc-storage-volume-bootable-lifecycle-il-%d", rInt)
-
-	imageListClient, err := getImageListClient()
-	if err != nil {
-		t.Fatalf("Error building Image List Client: %+v", err)
-	}
-
-	input := CreateImageListInput{
-		Name:        imageListName,
-		Description: "Test from the TestAccStorageVolumeBootableLifecycle",
-		Default:     1,
-	}
-	_, err = imageListClient.CreateImageList(&input)
-	if err != nil {
-		t.Fatalf("Error Creating Image List: %+v", err)
-	}
-	defer tearDownImageList(t, imageListClient, imageListName)
-
-	entryClient, err := getImageListEntriesClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	createEntryInput := &CreateImageListEntryInput{
-		Name:          imageListName,
-		MachineImages: []string{"/oracle/public/oel_6.7_apaas_16.4.5_1610211300"},
-		Version:       1,
-	}
-
-	createdImageListEntry, err := entryClient.CreateImageListEntry(createEntryInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer destroyImageListEntry(t, entryClient, createdImageListEntry)
+	imageListName := "/oracle/public/OL_7.2_UEKR4_x86_64"
 
 	createRequest := CreateStorageVolumeInput{
 		Name:        name,

--- a/compute/virtual_nic_test.go
+++ b/compute/virtual_nic_test.go
@@ -13,7 +13,7 @@ const (
 	_VirtNicInstanceTestName  = "test-acc-virt-nic"
 	_VirtNicInstanceTestLabel = "test"
 	_VirtNicInstanceTestShape = "oc3"
-	_VirtNicInstanceTestImage = "/oracle/public/Oracle_Solaris_11.3"
+	_VirtNicInstanceTestImage = "/oracle/public/OL_7.2_UEKR4_x86_64"
 )
 
 func TestAccVirtNICLifeCycle(t *testing.T) {


### PR DESCRIPTION
- Updated tests to consistently use the `/oracle/public/OL_7.2_UEKR4_x86_64` image list. This image is faster to launch than some of the older images user. Seeing about 25% reduction in time to execute all tests.

- Removed unnecessary creation of temporary image list for some test cases. Tests now use the main image list directly.