### PR TITLE
fix Availablility Domain json attribute name

### DIFF
--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -145,7 +145,7 @@ type ServiceInstance struct {
 	ApexURL string `json:"apex_url"`
 	// Applicable only in Oracle Cloud Infrastructure regions.
 	// Name of the availability domain within the region where the Oracle Database Cloud Service instance is provisioned.
-	AvailabilityDomain string `json:"availabilityDomain"`
+	AvailabilityDomain string `json:"availability_domain"`
 	// The backup configuration of the service instance.
 	BackupDestination string `json:"backup_destination"`
 	// The version of cloud tooling for backup and recovery supported by the service instance.


### PR DESCRIPTION
`AvailabilityDomain` json attribute name mapping was incorrect, so SDK was always returning `AvailabilityDomain` as blank.