### PR TITLE
Fix to monitor for Ready state

### DIFF
--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -624,10 +624,6 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 		}
 		return nil, serviceInstanceError
 	}
-	// Jobs are still running on  the instance after it's configured and we need to sleep until they are done.
-	//It doesn't take more than ten minutes however there isn't a way to check for completion
-	time.Sleep(10 * time.Minute)
-	return serviceInstance, nil
 }
 
 // WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.
@@ -643,10 +639,10 @@ func (c *ServiceInstanceClient) WaitForServiceInstanceRunning(input *GetServiceI
 		switch s := info.Status; s {
 		case ServiceInstanceRunning: // Target State
 			c.client.DebugLogString("Service Instance Running")
-			return false, nil
+			return true, nil
 		case ServiceInstanceConfigured:
 			c.client.DebugLogString("Service Instance Configured")
-			return true, nil
+			return false, nil
 		case ServiceInstanceInProgress:
 			c.client.DebugLogString("Service Instance is being created")
 			return false, nil

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -624,6 +624,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 		}
 		return nil, serviceInstanceError
 	}
+	return serviceInstance, nil
 }
 
 // WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	_ServiceInstanceName                        = "testing-db-service-instance"
+	_ServiceInstanceName                        = "testing-db-service-instance1"
 	_ServiceInstanceEdition                     = "EE"
 	_ServiceInstanceLevel                       = "PAAS"
 	_ServiceInstanceShape                       = "oc3"
@@ -21,7 +21,7 @@ const (
 	_ServiceInstanceDBSID                       = "ORCL"
 	_ServiceInstanceType                        = "db"
 	_ServiceInstanceUsableStorage               = "15"
-	_ServiceInstanceCloudStorageContainer       = "Storage-canonical/test-database-instance"
+	_ServiceInstanceCloudStorageContainer       = "Storage-a459477/test-database-instance"
 	_ServiceInstanceCloudStorageCreateIfMissing = true
 	_ServiceInstanceBackupDestinationBoth       = "BOTH"
 	_ServiceInstanceDeleteBackup                = true


### PR DESCRIPTION
Fixes the WaitForServiceInstanceRunning() to wait for "Running" instead of waiting for "Configured" + 10 minutes.

Resolves the issue where provisioning fails when state goes from "In Progress -> Configured -> Running" between polls so Configured status is never seen.
