### PR TITLE
Java ssh key trim

### DIFF
--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1329,7 +1329,10 @@ func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstan
 	}
 
 	// The JCS API errors if an ssh key has trailing content; we'll trim that here.
-	input.VMPublicKeyText = strings.Join(strings.Split(input.VMPublicKeyText, " ")[0:2], " ")
+	parts := strings.Split(input.VMPublicKeyText, " ")
+	if len(parts) > 2 {
+		input.VMPublicKeyText = strings.Join(parts[0:2], " ")
+	}
 
 	serviceInstance, err := c.startServiceInstance(input.ServiceName, input)
 	if err != nil {

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/client"
@@ -1326,6 +1327,9 @@ func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstan
 		input.CloudStorageUsername = *c.ResourceClient.JavaClient.client.UserName
 		input.CloudStoragePassword = *c.ResourceClient.JavaClient.client.Password
 	}
+
+	// The JCS API errors if an ssh key has trailing content; we'll trim that here.
+	input.VMPublicKeyText = strings.Join(strings.Split(input.VMPublicKeyText, " ")[0:2], " ")
 
 	serviceInstance, err := c.startServiceInstance(input.ServiceName, input)
 	if err != nil {


### PR DESCRIPTION
This PR trims ssh keys with trailing content that caused the JCS API to error. 
Fixes https://github.com/hashicorp/terraform-provider-oraclepaas/issues/18