### PR TITLE
Additional not found check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -298,6 +298,9 @@ func (c *Client) WaitFor(description string, pollInterval, timeout time.Duration
 func WasNotFoundError(e error) bool {
 	err, ok := e.(*opc.OracleError)
 	if ok {
+		if strings.Contains(err.Error(), "No such service exits") {
+			return true
+		}
 		return err.StatusCode == 404
 	}
 	return false


### PR DESCRIPTION
Java Service Instance Deletion was returning an error message of `No such service exits` instead of a 404. This PR adds an extra check in the WasNotFound method.