### PR TITLE
P scale db

### DIFF
--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -664,7 +664,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 		return nil, err
 	}
 
-	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	// Call wait for instance running now, as creating the instance is an eventually consistent operation
 	getInput := &GetServiceInstanceInput{
 		Name: name,
 	}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -837,7 +837,7 @@ func (c *ServiceInstanceClient) UpdateServiceInstance(input *UpdateServiceInstan
 		return nil, err
 	}
 
-	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	// Call wait for instance running now, as updating the instance is an eventually consistent operation
 	getInput := &GetServiceInstanceInput{
 		Name: input.Name,
 	}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -177,6 +177,16 @@ const (
 	ServiceInstanceTerminating ServiceInstanceState = "Terminating"
 )
 
+// ServiceInstanceUsage defines the constants for a service instance usage
+type ServiceInstanceUsage string
+
+const (
+	// ServiceInstanceUsageData extends the Data Storage Volume
+	ServiceInstanceUsageData ServiceInstanceUsage = "data"
+	// ServiceInstanceUsageFra extends the Backup Storage Volume
+	ServiceInstanceUsageFra ServiceInstanceUsage = "fra"
+)
+
 type ServiceInstance struct {
 	// The URL to use to connect to Oracle Application Express on the service instance.
 	ApexURL string `json:"apex_url"`
@@ -785,6 +795,60 @@ func (c *ServiceInstanceClient) WaitForServiceInstanceDeleted(input *GetServiceI
 			return false, nil
 		}
 	})
+}
+
+// UpdateServiceInstanceInput defines the attributes available to update for a service instance
+type UpdateServiceInstanceInput struct {
+	// Name of the service instance to update.
+	// Required
+	Name string `json:"-"`
+	// Specify size of additional storage in Giga Bytes. This parameter is optional. User can change shape
+	// only without adding storage. If additionalStorage is specified, minimum value is 1GB and maximum value is 1TB.
+	// Optional
+	AdditionalStorage string `json:"additionalStorage,omitempty"`
+	// (Applies only to service instances that use Oracle RAC and Oracle Data Guard together.)
+	// Specifies whether the scaling operation applies to the primary database or standby database of the
+	// Data Guard configuration. Specify the value DB_1 for the primary database or the value DB_2 for the
+	// standby database.
+	// Optional
+	ComponentInstanceName string `json:"componentInstanceName,omitempty"`
+	// Specify new shape for the Database Cloud Service instance. User can specify a higher shape (Scale Up) or
+	// a lower shape (Scale Down). Shape is optional. User can add storage only without changing shape.
+	// Optional
+	Shape ServiceInstanceShape `json:"shape,omitempty"`
+	// This parameter specifies usage of additional storage and is applicable only when additionalStorage is
+	// specified. Specify usage to extend Data or Backup storage volumes of Database Cloud Service instance.
+	// Valid values are data to extend Data Storage Volume and fra to extend Backup Storage Volume. If usage is
+	// not specified, new storage volume will be created.
+	// Optional
+	Usage ServiceInstanceUsage `json:"usage,omitempty"`
+}
+
+// UpdateServiceInstance updates the specified service instance
+func (c *ServiceInstanceClient) UpdateServiceInstance(input *UpdateServiceInstanceInput) (*ServiceInstance, error) {
+	if c.PollInterval == 0 {
+		c.PollInterval = WaitForServiceInstanceReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = WaitForServiceInstanceReadyTimeout
+	}
+
+	if err := c.updateResource(input.Name, *input, nil); err != nil {
+		return nil, err
+	}
+
+	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: input.Name,
+	}
+
+	// Wait for the service instance to be running and return the result
+	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
+	serviceInstance, err := c.WaitForServiceInstanceRunning(getInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("Error updating Service Instance %q: %+v", input.Name, err)
+	}
+	return serviceInstance, nil
 }
 
 func convertOracleBool(val bool) string {

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -13,6 +13,7 @@ const (
 	_ServiceInstanceEdition                     = "EE"
 	_ServiceInstanceLevel                       = "PAAS"
 	_ServiceInstanceShape                       = "oc3"
+	_ServiceInstanceUpdateShape                 = "oc4"
 	_ServiceInstanceSubscription                = "HOURLY"
 	_ServiceInstanceVersion                     = "12.2.0.1"
 	_ServiceInstancePubKey                      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
@@ -122,6 +123,65 @@ func TestAccServiceInstanceCloudStorage(t *testing.T) {
 	}
 	if receivedRes.CloudStorageContainer != _ServiceInstanceCloudStorageContainer {
 		t.Fatal(fmt.Errorf("Cloud storage containers do not match. Wanted: %s Received: %s", _ServiceInstanceCloudStorageContainer, receivedRes.CloudStorageContainer))
+	}
+}
+
+func TestAccServiceInstanceUpdate(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	siClient, err := getServiceInstanceTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	/*
+		parameter := ParameterInput{
+			AdminPassword:                   _ServiceInstancePassword,
+			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+			SID:                             _ServiceInstanceDBSID,
+			Type:                            _ServiceInstanceType,
+			UsableStorage:                   _ServiceInstanceUsableStorage,
+			CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
+			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+		}
+
+		createServiceInstance := &CreateServiceInstanceInput{
+			Name:             _ServiceInstanceName,
+			Edition:          _ServiceInstanceEdition,
+			Level:            _ServiceInstanceLevel,
+			Shape:            _ServiceInstanceShape,
+			SubscriptionType: _ServiceInstanceSubscription,
+			Version:          _ServiceInstanceVersion,
+			VMPublicKey:      _ServiceInstancePubKey,
+			Parameter:        parameter,
+		}
+
+		_, err = siClient.CreateServiceInstance(createServiceInstance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer destroyServiceInstance(t, siClient, _ServiceInstanceName)
+	*/
+
+	updateInput := &UpdateServiceInstanceInput{
+		Name:  "testing-java-instance-service3",
+		Shape: _ServiceInstanceUpdateShape,
+	}
+	_, err = siClient.UpdateServiceInstance(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getInput := &GetServiceInstanceInput{
+		Name: "testing-java-instance-service3", // _ServiceInstanceName,
+	}
+
+	receivedRes, err := siClient.GetServiceInstance(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.Shape != _ServiceInstanceUpdateShape {
+		t.Fatal(fmt.Errorf("Shapes do not match. Wanted: %s Received: %s", _ServiceInstanceUpdateShape, receivedRes.Shape))
 	}
 }
 

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -134,37 +134,35 @@ func TestAccServiceInstanceUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	/*
-		parameter := ParameterInput{
-			AdminPassword:                   _ServiceInstancePassword,
-			BackupDestination:               _ServiceInstanceBackupDestinationBoth,
-			SID:                             _ServiceInstanceDBSID,
-			Type:                            _ServiceInstanceType,
-			UsableStorage:                   _ServiceInstanceUsableStorage,
-			CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
-			CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
-		}
+	parameter := ParameterInput{
+		AdminPassword:                   _ServiceInstancePassword,
+		BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+		SID:                             _ServiceInstanceDBSID,
+		Type:                            _ServiceInstanceType,
+		UsableStorage:                   _ServiceInstanceUsableStorage,
+		CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+	}
 
-		createServiceInstance := &CreateServiceInstanceInput{
-			Name:             _ServiceInstanceName,
-			Edition:          _ServiceInstanceEdition,
-			Level:            _ServiceInstanceLevel,
-			Shape:            _ServiceInstanceShape,
-			SubscriptionType: _ServiceInstanceSubscription,
-			Version:          _ServiceInstanceVersion,
-			VMPublicKey:      _ServiceInstancePubKey,
-			Parameter:        parameter,
-		}
+	createServiceInstance := &CreateServiceInstanceInput{
+		Name:             _ServiceInstanceName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscription,
+		Version:          _ServiceInstanceVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        parameter,
+	}
 
-		_, err = siClient.CreateServiceInstance(createServiceInstance)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer destroyServiceInstance(t, siClient, _ServiceInstanceName)
-	*/
+	_, err = siClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyServiceInstance(t, siClient, _ServiceInstanceName)
 
 	updateInput := &UpdateServiceInstanceInput{
-		Name:  "testing-java-instance-service3",
+		Name:  _ServiceInstanceName,
 		Shape: _ServiceInstanceUpdateShape,
 	}
 	_, err = siClient.UpdateServiceInstance(updateInput)
@@ -173,7 +171,7 @@ func TestAccServiceInstanceUpdate(t *testing.T) {
 	}
 
 	getInput := &GetServiceInstanceInput{
-		Name: "testing-java-instance-service3", // _ServiceInstanceName,
+		Name: _ServiceInstanceName,
 	}
 
 	receivedRes, err := siClient.GetServiceInstance(getInput)


### PR DESCRIPTION
This PR adds the ability to scale up and down a service instance 

```
make testacc TEST=./database TESTARGS="-run=TestAccServiceInstanceUpdate"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccServiceInstanceUpdate -timeout 120m
=== RUN   TestAccServiceInstanceUpdate
--- PASS: TestAccServiceInstanceUpdate (3458.23s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/database	3458.248s
```