### PR TITLE
P db desired state

### DIFF
--- a/database/database_resource_client.go
+++ b/database/database_resource_client.go
@@ -26,8 +26,8 @@ func (c *ResourceClient) createResource(requestBody interface{}, responseBody in
 	return nil
 }
 
-func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
-	_, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}, method string) error {
+	_, err := c.executeRequest(method, c.getObjectPath(c.ResourceRootPath, name), requestBody)
 	if err != nil {
 		return err
 	}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -187,6 +187,18 @@ const (
 	ServiceInstanceUsageFra ServiceInstanceUsage = "fra"
 )
 
+// ServiceInstanceLifecycleState defines the constants for the lifecycle state
+type ServiceInstanceLifecycleState string
+
+const (
+	// ServiceInstanceLifecycleStateStop - stop: Stops the Database Cloud Service instance or compute node.
+	ServiceInstanceLifecycleStateStop ServiceInstanceLifecycleState = "stop"
+	// ServiceInstanceLifecycleStateStart - start: Starts the Database Cloud Service instance or compute node.
+	ServiceInstanceLifecycleStateStart ServiceInstanceLifecycleState = "start"
+	// ServiceInstanceLifecycleStateRestart - restart: Restarts the Database Cloud Service instance or compute node.
+	ServiceInstanceLifecycleStateRestart ServiceInstanceLifecycleState = "restart"
+)
+
 type ServiceInstance struct {
 	// The URL to use to connect to Oracle Application Express on the service instance.
 	ApexURL string `json:"apex_url"`
@@ -671,7 +683,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 
 	// Wait for the service instance to be running and return the result
 	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
-	serviceInstance, serviceInstanceError := c.WaitForServiceInstanceRunning(getInput, c.PollInterval, c.Timeout)
+	serviceInstance, serviceInstanceError := c.WaitForServiceInstanceState(getInput, ServiceInstanceLifecycleStateStart, c.PollInterval, c.Timeout)
 	// If the service instance enters an error state we need to delete the instance and retry
 	if serviceInstanceError != nil {
 		deleteInput := &DeleteServiceInstanceInput{
@@ -687,7 +699,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 }
 
 // WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.
-func (c *ServiceInstanceClient) WaitForServiceInstanceRunning(input *GetServiceInstanceInput, pollInterval, timeoutSeconds time.Duration) (*ServiceInstance, error) {
+func (c *ServiceInstanceClient) WaitForServiceInstanceState(input *GetServiceInstanceInput, desiredState ServiceInstanceLifecycleState, pollInterval, timeoutSeconds time.Duration) (*ServiceInstance, error) {
 	var info *ServiceInstance
 	var getErr error
 	err := c.client.WaitFor("service instance to be ready", pollInterval, timeoutSeconds, func() (bool, error) {
@@ -697,14 +709,26 @@ func (c *ServiceInstanceClient) WaitForServiceInstanceRunning(input *GetServiceI
 		}
 		c.client.DebugLogString(fmt.Sprintf("Service instance name is %v, Service instance info is %+v", info.Name, info))
 		switch s := info.Status; s {
-		case ServiceInstanceRunning: // Target State
+		case ServiceInstanceRunning:
 			c.client.DebugLogString("Service Instance Running")
-			return true, nil
+			if desiredState == ServiceInstanceLifecycleStateStart || desiredState == ServiceInstanceLifecycleStateRestart {
+				return true, nil
+			}
+			return false, nil
 		case ServiceInstanceConfigured:
 			c.client.DebugLogString("Service Instance Configured")
 			return false, nil
 		case ServiceInstanceInProgress:
 			c.client.DebugLogString("Service Instance is being created")
+			return false, nil
+		case ServiceInstanceMaintenance:
+			c.client.DebugLogString("ServiceInstance is in maintenance")
+			return false, nil
+		case ServiceInstanceStopped:
+			c.client.DebugLogString("Service Instance is stopped")
+			if desiredState == ServiceInstanceLifecycleStateStop {
+				return true, nil
+			}
 			return false, nil
 		default:
 			c.client.DebugLogString(fmt.Sprintf("Unknown instance state: %s, waiting", s))
@@ -749,6 +773,34 @@ func (c *ServiceInstanceClient) DeleteServiceInstance(input *DeleteServiceInstan
 	if c.Timeout == 0 {
 		c.Timeout = WaitForServiceInstanceDeleteTimeout
 	}
+
+	// We can't delete backups if the instance is stopped so we'll start the instance if that is the case.
+	if input.DeleteBackup {
+		getInput := &GetServiceInstanceInput{
+			Name: input.Name,
+		}
+
+		info, err := c.GetServiceInstance(getInput)
+		if err != nil {
+			if client.WasNotFoundError(err) {
+				// Service Instance could not be found, thus deleted
+				return nil
+			}
+			// Some other error occurred trying to get instance, exit
+			return err
+		}
+		if info.Status == ServiceInstanceStopped {
+			updateDesiredStateInput := &DesiredStateInput{
+				Name:           input.Name,
+				LifecycleState: ServiceInstanceLifecycleStateStart,
+			}
+			_, err = c.UpdateDesiredState(updateDesiredStateInput)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	// Call to delete the service instance
 	// If delete fails, rerun it in case the instance still has not been setup correctly.
 	// An instance takes additional time to setup after it's configured.
@@ -833,7 +885,7 @@ func (c *ServiceInstanceClient) UpdateServiceInstance(input *UpdateServiceInstan
 		c.Timeout = WaitForServiceInstanceReadyTimeout
 	}
 
-	if err := c.updateResource(input.Name, *input, nil); err != nil {
+	if err := c.updateResource(input.Name, *input, nil, "PUT"); err != nil {
 		return nil, err
 	}
 
@@ -844,7 +896,51 @@ func (c *ServiceInstanceClient) UpdateServiceInstance(input *UpdateServiceInstan
 
 	// Wait for the service instance to be running and return the result
 	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
-	serviceInstance, err := c.WaitForServiceInstanceRunning(getInput, c.PollInterval, c.Timeout)
+	serviceInstance, err := c.WaitForServiceInstanceState(getInput, ServiceInstanceLifecycleStateStart, c.PollInterval, c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("Error updating Service Instance %q: %+v", input.Name, err)
+	}
+	return serviceInstance, nil
+}
+
+// DesiredStateInput defines the attributes available when setting the desired state of a service instance
+type DesiredStateInput struct {
+	// Name of the service instance to update.
+	// Required
+	Name string `json:"-"`
+	// Type of the request.
+	// Required
+	LifecycleState ServiceInstanceLifecycleState `json:"lifecycleState"`
+	// Timeout (minutes) for each request. The range of valid values are 1 to 300 minutes (inclusive).
+	// This value defaults to 60 minutes.
+	// Optional
+	LifecycleTimeout string `json:"lifecycleTimeout,omitempty"`
+	// Name of compute node to stop, start, or restart.
+	// Optional
+	VMName string `json:"vmName,omitempty"`
+}
+
+// UpdateDesiredState updates the specified desired state of a service instance
+func (c *ServiceInstanceClient) UpdateDesiredState(input *DesiredStateInput) (*ServiceInstance, error) {
+	if c.PollInterval == 0 {
+		c.PollInterval = WaitForServiceInstanceReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = WaitForServiceInstanceReadyTimeout
+	}
+
+	if err := c.updateResource(input.Name, *input, nil, "POST"); err != nil {
+		return nil, err
+	}
+
+	// Call wait for instance running now, as updating the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: input.Name,
+	}
+
+	// Wait for the service instance to be running and return the result
+	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
+	serviceInstance, err := c.WaitForServiceInstanceState(getInput, input.LifecycleState, c.PollInterval, c.Timeout)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating Service Instance %q: %+v", input.Name, err)
 	}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -698,7 +698,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 	return serviceInstance, nil
 }
 
-// WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.
+// WaitForServiceInstanceState waits for a service instance to be in the desired state
 func (c *ServiceInstanceClient) WaitForServiceInstanceState(input *GetServiceInstanceInput, desiredState ServiceInstanceLifecycleState, pollInterval, timeoutSeconds time.Duration) (*ServiceInstance, error) {
 	var info *ServiceInstance
 	var getErr error
@@ -889,7 +889,7 @@ func (c *ServiceInstanceClient) UpdateServiceInstance(input *UpdateServiceInstan
 		return nil, err
 	}
 
-	// Call wait for instance running now, as updating the instance is an eventually consistent operation
+	// Call wait for instance state now, as updating the instance is an eventually consistent operation
 	getInput := &GetServiceInstanceInput{
 		Name: input.Name,
 	}

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -236,7 +236,7 @@ func TestAccServiceInstanceDesiredState(t *testing.T) {
 		t.Fatal(err)
 	}
 	if receivedRes.Status != ServiceInstanceStopped {
-		t.Fatal(fmt.Errorf("Statu do not match. Wanted: %s Received: %s", ServiceInstanceStopped, receivedRes.Status))
+		t.Fatal(fmt.Errorf("Statuses do not match. Wanted: %s Received: %s", ServiceInstanceStopped, receivedRes.Status))
 	}
 }
 

--- a/database/service_instance_test.go
+++ b/database/service_instance_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	_ServiceInstanceName                        = "testing-db-service-instance1"
+	_ServiceInstanceName                        = "testing-db-service-instance"
 	_ServiceInstanceEdition                     = "EE"
 	_ServiceInstanceLevel                       = "PAAS"
 	_ServiceInstanceShape                       = "oc3"
@@ -180,6 +180,63 @@ func TestAccServiceInstanceUpdate(t *testing.T) {
 	}
 	if receivedRes.Shape != _ServiceInstanceUpdateShape {
 		t.Fatal(fmt.Errorf("Shapes do not match. Wanted: %s Received: %s", _ServiceInstanceUpdateShape, receivedRes.Shape))
+	}
+}
+
+func TestAccServiceInstanceDesiredState(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	siClient, err := getServiceInstanceTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parameter := ParameterInput{
+		AdminPassword:                   _ServiceInstancePassword,
+		BackupDestination:               _ServiceInstanceBackupDestinationBoth,
+		SID:                             _ServiceInstanceDBSID,
+		Type:                            _ServiceInstanceType,
+		UsableStorage:                   _ServiceInstanceUsableStorage,
+		CloudStorageContainer:           _ServiceInstanceCloudStorageContainer,
+		CreateStorageContainerIfMissing: _ServiceInstanceCloudStorageCreateIfMissing,
+	}
+
+	createServiceInstance := &CreateServiceInstanceInput{
+		Name:             _ServiceInstanceName,
+		Edition:          _ServiceInstanceEdition,
+		Level:            _ServiceInstanceLevel,
+		Shape:            _ServiceInstanceShape,
+		SubscriptionType: _ServiceInstanceSubscription,
+		Version:          _ServiceInstanceVersion,
+		VMPublicKey:      _ServiceInstancePubKey,
+		Parameter:        parameter,
+	}
+
+	_, err = siClient.CreateServiceInstance(createServiceInstance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroyServiceInstance(t, siClient, _ServiceInstanceName)
+
+	desiredStateInput := &DesiredStateInput{
+		Name:           _ServiceInstanceName,
+		LifecycleState: ServiceInstanceLifecycleStateStop,
+	}
+	_, err = siClient.UpdateDesiredState(desiredStateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getInput := &GetServiceInstanceInput{
+		Name: _ServiceInstanceName,
+	}
+
+	receivedRes, err := siClient.GetServiceInstance(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.Status != ServiceInstanceStopped {
+		t.Fatal(fmt.Errorf("Statu do not match. Wanted: %s Received: %s", ServiceInstanceStopped, receivedRes.Status))
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to set the desired state of a database service instance 

```
make testacc TEST=./database  TESTARGS="-run=TestAccServiceInstanceDesiredState"
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./database -run=TestAccServiceInstanceDesiredState -timeout 120m
=== RUN   TestAccServiceInstanceDesiredState
--- PASS: TestAccServiceInstanceDesiredState (3841.91s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/database	3841.928s
```