### PR TITLE
Removing constants from Service Version

### DIFF
--- a/database/access_rules.go
+++ b/database/access_rules.go
@@ -24,7 +24,7 @@ const (
 )
 
 // WaitForAccessRuleTimeout - Default Timeout value for Create
-const WaitForAccessRuleTimeout = 10 * time.Second
+const WaitForAccessRuleTimeout = 10 * time.Minute
 
 // WaitForAccessRulePollInterval - Default Poll Interval value for Create
 const WaitForAccessRulePollInterval = 1 * time.Second

--- a/java/access_rules.go
+++ b/java/access_rules.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Default Timeout value for Create
-const waitForAccessRuleTimeout = 10 * time.Second
+const waitForAccessRuleTimeout = 10 * time.Minute
 
 // Default Poll Interval value for Create
 const waitForAccessRulePollInterval = 1 * time.Second

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -284,20 +284,6 @@ const (
 	ServiceInstanceStatusTerminated ServiceInstanceStatus = "TERMINATED"
 )
 
-// ServiceInstanceMiddlewareVersion specifies the constants for the middleware version of a service instance
-type ServiceInstanceMiddlewareVersion string
-
-const (
-  // ServiceInstanceMiddlewareVersion12c213 - 12cRelease213
-	ServiceInstanceMiddlewareVersion12c213 ServiceInstanceMiddlewareVersion = "12cRelease213"
-	// ServiceInstanceMiddlewareVersion12c212 - 12cRelease212
-	ServiceInstanceMiddlewareVersion12c212 ServiceInstanceMiddlewareVersion = "12cRelease212"
-	// ServiceInstanceMiddlewareVersion12cR3 - 12cR3
-	ServiceInstanceMiddlewareVersion12cR3 ServiceInstanceMiddlewareVersion = "12cR3"
-	// ServiceInstanceMiddlewareVersion11gR1 - 11gR1
-	ServiceInstanceMiddlewareVersion11gR1 ServiceInstanceMiddlewareVersion = "11gR1"
-)
-
 // ServiceInstanceClusterType are the constances around cluster types for a service instance
 type ServiceInstanceClusterType string
 
@@ -863,7 +849,7 @@ type CreateServiceInstanceInput struct {
 	// Only 12cRelease212 is valid if you are using upperStackProductName to provision a service instance for an Oracle
 	// Fusion Middleware product.
 	// Optional
-	ServiceVersion ServiceInstanceMiddlewareVersion `json:"serviceVersion,omitempty"`
+	ServiceVersion string `json:"serviceVersion,omitempty"`
 	// This attribute is applicable only to provisioning on Oracle Cloud Infrastructure Classic.
 	// This attribute and sourceServiceName are required when you provision a clone of an existing Oracle
 	// Java Cloud Service instance (the source service instance).


### PR DESCRIPTION
The Middleware Version tends to change more frequently than users would like. We're omitting it here so users can use the latest version when it arrives rather than waiting for an sdk release and then a provider release.

Also this PR bumps out the Timeout to the correct time in minutes rather than seconds