### PR TITLE
Add assignPublicIP attribute for Java Cloud Service

### DIFF
--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -710,7 +710,7 @@ type CreateServiceInstanceInput struct {
 	// network is specified in ipNetwork. Flag that specifies whether to assign (true)
 	// or not assign (false) public IP addresses to the nodes in your service instance.
 	// Optional.
-	AssignPublicIP string `json:"assignPublicIP,omitempty"`
+	AssignPublicIP bool `json:"assignPublicIP,omitempty"`
 	// This attribute is available only on Oracle Cloud Infrastructure. It is required along with region and subnet.
 	// Name of a data center location in the Oracle Cloud Infrastructure region that is specified in region.
 	// A region is a localized geographic area, composed of one or more availability domains (data centers).

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -705,6 +705,12 @@ type IPReservation struct {
 
 // CreateServiceInstanceInput specifies the attributes of the service instance that will be created
 type CreateServiceInstanceInput struct {
+	// This attribute is only applicable when provisioning an Oracle Java Cloud Service
+	// instance in a region on Oracle Cloud Infrastructure Classic, and a custom IP
+	// network is specified in ipNetwork. Flag that specifies whether to assign (true)
+	// or not assign (false) public IP addresses to the nodes in your service instance.
+	// Optional.
+	AssignPublicIP string `json:"assignPublicIP,omitempty"`
 	// This attribute is available only on Oracle Cloud Infrastructure. It is required along with region and subnet.
 	// Name of a data center location in the Oracle Cloud Infrastructure region that is specified in region.
 	// A region is a localized geographic area, composed of one or more availability domains (data centers).


### PR DESCRIPTION
Adds support for setting `assignPublicIP` when creating JCS instances.