### PR TITLE
P application container

### DIFF
--- a/application/application_client.go
+++ b/application/application_client.go
@@ -1,8 +1,13 @@
 package application
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/opc"
@@ -25,8 +30,8 @@ func NewClient(c *opc.Config) (*Client, error) {
 	return appClient, nil
 }
 
-func (c *Client) executeCreateUpdateRequest(method, path string, files map[string]string, parameters map[string]interface{}) (*http.Response, error) {
-	req, err := c.client.BuildMultipartFormRequest(method, path, files, parameters)
+func (c *Client) executeCreateUpdateRequest(method, path string, input *CreateApplicationContainerInput) (*http.Response, error) {
+	req, err := c.client.BuildMultipartFormRequest(method, path, input)
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +81,51 @@ func (c *Client) executeRequest(method, path string, body interface{}) (*http.Re
 		return nil, err
 	}
 	return resp, nil
+}
+
+// BuildMultipartFormRequest builds a new HTTP Request for a multipart form request from specifies attributes
+func (c *Client) BuildMultipartFormRequest(method, path string, manifestBody interface{}, parameters map[string]interface{}) (*http.Request, error) {
+
+	urlPath, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+
+	var (
+		part io.Writer
+	)
+
+	part, err = writer.CreateFormFile("manifest", "manifest.json")
+	if err != nil {
+		return nil, err
+	}
+	manifestBytes, err := c.client.MarshallRequestBody(manifestBody)
+	if err != nil {
+		return nil, err
+	}
+	_, err = part.Write(manifestBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add additional parameters to the writer
+	for key, val := range parameters {
+		if val.(string) != "" {
+			_ = writer.WriteField(strings.ToLower(key), val.(string))
+		}
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", c.formatURL(urlPath), body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	return req, err
 }
 
 func (c *Client) getContainerPath(root string) string {

--- a/application/application_container.go
+++ b/application/application_container.go
@@ -133,6 +133,8 @@ type Container struct {
 	AppURL string `json:"appURL"`
 	// Creation time of the application
 	CreatedTime string `json:"createdTime"`
+	// The activity acting on the application container
+	CurrentOnGoingActitvity string `json:"currentOngoingActivity"`
 	// Identity Domain of the application
 	IdentityDomain string `json:"identityDomain"`
 	// Shows details of all instances currently running.
@@ -575,6 +577,9 @@ func (c *ContainerClient) WaitForApplicationContainerRunning(input *GetApplicati
 		c.client.DebugLogString(fmt.Sprintf("Application Container name is %v, Application Contiainer info is %+v", info.Name, info))
 		switch s := info.Status; s {
 		case string(applicationContainerStatusRunning): // Target State
+			if info.CurrentOnGoingActitvity != "" {
+				return false, nil
+			}
 			c.client.DebugLogString("Application Container Running")
 			return true, nil
 		case string(applicationContainerStatusNew):

--- a/application/application_container_test.go
+++ b/application/application_container_test.go
@@ -102,7 +102,7 @@ func TestAccApplicationContainerLifeCycle_ManifestFile(t *testing.T) {
 	assert.Equal(t, "RUNNING", applicationContainer.Status)
 }
 
-func TestAccApplicationContainerLifeCycle_TwoManifest(t *testing.T) {
+func TestAccApplicationContainerLifeCycle_BadInput(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
 	aClient, err := getApplicationContainerTestClients()
@@ -132,6 +132,28 @@ func TestAccApplicationContainerLifeCycle_TwoManifest(t *testing.T) {
 		Manifest:           _ApplicationContainerManifestFile,
 	}
 
+	_, err = aClient.CreateApplicationContainer(createApplicationContainerInput)
+	if err == nil {
+		t.Fatal("expected error when specifiying both a manifest file and manifest attributes")
+	}
+
+	environment := map[string]string{
+		"NO_OF_CONNECTIONS": "25",
+		"TWITTER_ID":        "JAVA",
+	}
+
+	deployment := &DeploymentAttributes{
+		Memory:      "2G",
+		Instances:   1,
+		Envrionment: environment,
+	}
+
+	createApplicationContainerInput = &CreateApplicationContainerInput{
+		AdditionalFields:     createApplicationContainerAdditionalFields,
+		DeploymentAttributes: deployment,
+		Manifest:             _ApplicationContainerManifestFile,
+		Deployment:           _ApplicationContainerDeploymentFile,
+	}
 	_, err = aClient.CreateApplicationContainer(createApplicationContainerInput)
 	if err == nil {
 		t.Fatal("expected error when specifiying both a manifest file and manifest attributes")

--- a/application/application_container_test.go
+++ b/application/application_container_test.go
@@ -55,7 +55,7 @@ func TestAccApplicationContainerLifeCycle_Basic(t *testing.T) {
 	assert.Equal(t, "RUNNING", applicationContainer.Status)
 }
 
-func TestAccApplicationContainerLifeCycle_Manifest(t *testing.T) {
+func TestAccApplicationContainerLifeCycle_ManifestFile(t *testing.T) {
 	helper.Test(t, helper.TestCase{})
 
 	aClient, err := getApplicationContainerTestClients()
@@ -71,6 +71,107 @@ func TestAccApplicationContainerLifeCycle_Manifest(t *testing.T) {
 	createApplicationContainerInput := &CreateApplicationContainerInput{
 		AdditionalFields: createApplicationContainerAdditionalFields,
 		Manifest:         _ApplicationContainerManifestFile,
+	}
+
+	createdApplicationContainer, err := aClient.CreateApplicationContainer(createApplicationContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully created Application Container: %+v", createdApplicationContainer)
+	defer deleteTestApplicationContainer(t, aClient, _ApplicationContainerTestName)
+
+	getInput := &GetApplicationContainerInput{
+		Name: _ApplicationContainerTestName,
+	}
+
+	applicationContainer, err := aClient.GetApplicationContainer(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("Application Container Retrieved: %+v", applicationContainer)
+	assert.NotEmpty(t, applicationContainer.Name, "Expected Application Container name not to be empty")
+	assert.Equal(t, _ApplicationContainerTestName, applicationContainer.Name, "Expected Application Container and name to match.")
+	assert.Equal(t, "RUNNING", applicationContainer.Status)
+}
+
+func TestAccApplicationContainerLifeCycle_TwoManifest(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	aClient, err := getApplicationContainerTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := &ManifestAttributes{
+		Command: "sh target/bin/start",
+		Notes:   "notes related to release",
+		Mode:    "rolling",
+		Runtime: Runtime{MajorVersion: "7"},
+		Release: Release{Build: "150520.1154",
+			Commit:  "d8c2596364d9584050461",
+			Version: "15.1.0"},
+	}
+
+	createApplicationContainerAdditionalFields := CreateApplicationContainerAdditionalFields{
+		Name:    _ApplicationContainerTestName,
+		Runtime: _ApplicationContainerRuntimeJava,
+	}
+
+	createApplicationContainerInput := &CreateApplicationContainerInput{
+		AdditionalFields:   createApplicationContainerAdditionalFields,
+		ManifestAttributes: manifest,
+		Manifest:           _ApplicationContainerManifestFile,
+	}
+
+	createdApplicationContainer, err := aClient.CreateApplicationContainer(createApplicationContainerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("Successfully created Application Container: %+v", createdApplicationContainer)
+	defer deleteTestApplicationContainer(t, aClient, _ApplicationContainerTestName)
+
+	getInput := &GetApplicationContainerInput{
+		Name: _ApplicationContainerTestName,
+	}
+
+	applicationContainer, err := aClient.GetApplicationContainer(getInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("Application Container Retrieved: %+v", applicationContainer)
+	assert.NotEmpty(t, applicationContainer.Name, "Expected Application Container name not to be empty")
+	assert.Equal(t, _ApplicationContainerTestName, applicationContainer.Name, "Expected Application Container and name to match.")
+	assert.Equal(t, "RUNNING", applicationContainer.Status)
+}
+
+func TestAccApplicationContainerLifeCycle_ManifestAttr(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	aClient, err := getApplicationContainerTestClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := &ManifestAttributes{
+		Command: "sh target/bin/start",
+		Notes:   "notes related to release",
+		Mode:    "rolling",
+		Runtime: Runtime{MajorVersion: "7"},
+		Release: Release{Build: "150520.1154",
+			Commit:  "d8c2596364d9584050461",
+			Version: "15.1.0"},
+	}
+
+	createApplicationContainerAdditionalFields := CreateApplicationContainerAdditionalFields{
+		Name:    _ApplicationContainerTestName,
+		Runtime: _ApplicationContainerRuntimeJava,
+	}
+
+	createApplicationContainerInput := &CreateApplicationContainerInput{
+		AdditionalFields:   createApplicationContainerAdditionalFields,
+		ManifestAttributes: manifest,
 	}
 
 	createdApplicationContainer, err := aClient.CreateApplicationContainer(createApplicationContainerInput)

--- a/application/application_resource_client.go
+++ b/application/application_resource_client.go
@@ -16,8 +16,8 @@ type ResourceClient struct {
 	ResourceRootPath string
 }
 
-func (c *ResourceClient) createResource(files map[string]string, additionalParams map[string]interface{}, responseBody interface{}) error {
-	_, err := c.executeCreateUpdateRequest("POST", c.getContainerPath(c.ContainerPath), files, additionalParams)
+func (c *ResourceClient) createApplicationContainerResource(input *CreateApplicationContainerInput, responseBody interface{}) error {
+	_, err := c.executeCreateUpdateRequest("POST", c.getContainerPath(c.ContainerPath), input)
 
 	return err
 }

--- a/application/application_resource_client.go
+++ b/application/application_resource_client.go
@@ -16,14 +16,14 @@ type ResourceClient struct {
 	ResourceRootPath string
 }
 
-func (c *ResourceClient) createApplicationContainerResource(input *CreateApplicationContainerInput, responseBody interface{}) error {
-	_, err := c.executeCreateUpdateRequest("POST", c.getContainerPath(c.ContainerPath), input)
+func (c *ResourceClient) createApplicationContainerResource(method string, files map[string][]byte, additionalParams map[string]interface{}, responseBody interface{}) error {
+	_, err := c.executeCreateUpdateApplicationContainer(method, c.getContainerPath(c.ContainerPath), files, additionalParams)
 
 	return err
 }
 
-func (c *ResourceClient) updateResource(files map[string]string, additionalParams map[string]interface{}, responseBody interface{}) error {
-	_, err := c.executeCreateUpdateRequest("PUT", c.getContainerPath(c.ContainerPath), files, additionalParams)
+func (c *ResourceClient) updateApplicationContainerResource(name string, method string, files map[string][]byte, additionalParams map[string]interface{}, responseBody interface{}) error {
+	_, err := c.executeCreateUpdateApplicationContainer(method, c.getObjectPath(c.ResourceRootPath, name), files, additionalParams)
 
 	return err
 }

--- a/application/utils_test.go
+++ b/application/utils_test.go
@@ -28,7 +28,7 @@ func getApplicationTestClient(c *opc.Config) (*Client, error) {
 	}
 
 	if c.APIEndpoint == nil {
-		apiEndpoint, err := url.Parse(os.Getenv("OPC_APPLICATION_ENDPOINT"))
+		apiEndpoint, err := url.Parse(os.Getenv("ORACLEPAAS_APPLICATION_ENDPOINT"))
 		if err != nil {
 			return nil, err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -8,7 +8,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -141,56 +140,6 @@ func (c *Client) BuildNonJSONRequest(method, path string, body io.Reader) (*http
 	req.Header.Add(userAgentHeader, *c.UserAgent)
 
 	return req, nil
-}
-
-// BuildMultipartFormRequestFromFiles builds a new HTTP Request for a multipart form request from specifies files
-func (c *Client) BuildMultipartFormRequestFromFiles(method, path string, files map[string][]byte, parameters map[string]interface{}) (*http.Request, error) {
-	urlPath, err := url.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-
-	body := new(bytes.Buffer)
-	writer := multipart.NewWriter(body)
-
-	var (
-		file *os.File
-		fi   os.FileInfo
-		part io.Writer
-	)
-	for fileName, fileContents := range files {
-
-		// Write out the file information and contents
-		fi, err = file.Stat()
-		if err != nil {
-			return nil, err
-		}
-		part, err = writer.CreateFormFile(fileName, fi.Name())
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = part.Write(fileContents)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Add additional parameters to the writer
-	for key, val := range parameters {
-		if val.(string) != "" {
-			_ = writer.WriteField(strings.ToLower(key), val.(string))
-		}
-	}
-	err = writer.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", c.formatURL(urlPath), body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-
-	return req, err
 }
 
 // BuildMultipartFormRequest builds a new HTTP Request for a multipart form request from specifies attributes

--- a/client/client.go
+++ b/client/client.go
@@ -230,7 +230,7 @@ func (c *Client) BuildMultipartFormRequest(method, path string, files map[string
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.formatURL(urlPath), body)
+	req, err := http.NewRequest(method, c.formatURL(urlPath), body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	return req, err


### PR DESCRIPTION
This PR adds the ability to pass in the manifest and deployment attributes into the sdk rather than those respective files

```
=== RUN   TestAccApplicationContainerLifeCycle_Basic
--- PASS: TestAccApplicationContainerLifeCycle_Basic (175.06s)
=== RUN   TestAccApplicationContainerLifeCycle_ManifestFile
--- PASS: TestAccApplicationContainerLifeCycle_ManifestFile (188.34s)
=== RUN   TestAccApplicationContainerLifeCycle_TwoManifest
--- PASS: TestAccApplicationContainerLifeCycle_TwoManifest (0.00s)
=== RUN   TestAccApplicationContainerLifeCycle_ManifestAttr
--- PASS: TestAccApplicationContainerLifeCycle_ManifestAttr (203.62s)
=== RUN   TestAccApplicationContainerLifeCycle_Deployment
--- PASS: TestAccApplicationContainerLifeCycle_Deployment (119.09s)
=== RUN   TestAccApplicationContainerLifeCycle_DeploymentAttr
--- PASS: TestAccApplicationContainerLifeCycle_DeploymentAttr (274.22s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/application	960.345s
```