### PR TITLE
Adding jobs to java service instance

### DIFF
--- a/java/java_resource_client.go
+++ b/java/java_resource_client.go
@@ -36,9 +36,12 @@ func (c *ResourceClient) getResource(name string, responseBody interface{}) erro
 	return c.unmarshalResponseBody(resp, responseBody)
 }
 
-func (c *ResourceClient) updateResource(name, path, method string, requestBody interface{}) error {
-	_, err := c.executeRequest(method, fmt.Sprintf("%s%s", c.getObjectPath(c.ResourceRootPath, name), path), requestBody)
-	return err
+func (c *ResourceClient) updateResource(name, path, method string, requestBody interface{}, responseBody interface{}) error {
+	resp, err := c.executeRequest(method, fmt.Sprintf("%s%s", c.getObjectPath(c.ResourceRootPath, name), path), requestBody)
+	if err != nil {
+		return err
+	}
+	return c.unmarshalResponseBody(resp, responseBody)
 }
 
 // ServiceInstance needs a PUT and a body to be destroyed

--- a/java/jobs.go
+++ b/java/jobs.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// API URI Paths for Container and Root objects
+// API URI Paths for the Root Job path
 const (
 	JobRootPath = "/paas/api/v1.1/activitylog/%s/job/%s"
 )
@@ -13,7 +13,7 @@ const (
 // Default Poll Interval value
 const waitForJobPollInterval = 1 * time.Second
 
-// JobClient is a client for the Service functions of the Java API.
+// JobClient is a client for the Service functions of the Job API.
 type JobClient struct {
 	ResourceClient
 	PollInterval time.Duration
@@ -63,7 +63,7 @@ type Job struct {
 
 // GetJobInput specifies which job to retrieve
 type GetJobInput struct {
-	// Name of the Java Cloud Service instance.
+	// ID of the job.
 	// Required.
 	ID string
 }

--- a/java/jobs.go
+++ b/java/jobs.go
@@ -1,0 +1,104 @@
+package java
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for Container and Root objects
+const (
+	JobRootPath = "/paas/api/v1.1/activitylog/%s/job/%s"
+)
+
+// Default Poll Interval value
+const waitForJobPollInterval = 1 * time.Second
+
+// JobClient is a client for the Service functions of the Java API.
+type JobClient struct {
+	ResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// Jobs returns a JobClient for checking job status
+func (c *Client) Jobs() *JobClient {
+	return &JobClient{
+		ResourceClient: ResourceClient{
+			Client:           c,
+			ResourceRootPath: JobRootPath,
+		},
+	}
+}
+
+// JobStatus defines the constants for the status of a job
+type JobStatus string
+
+const (
+	// JobStatusRunning - the job is still running.
+	JobStatusRunning JobStatus = "RUNNING"
+	// JobStatusFailed - the job has failed.
+	JobStatusFailed JobStatus = "FAILED"
+	// JobStatusSucceed - the job has succeeded.
+	JobStatusSucceed JobStatus = "SUCCEED"
+)
+
+// JobResponse details the job information received after submitting a request
+type JobResponse struct {
+	Details Details `json:"details"`
+}
+
+// Details details the attributes of the specific job that is running on the service instance
+type Details struct {
+	JobID   string `json:"jobId"`
+	Message string `json:"message"`
+}
+
+// Job details the attributes related to a job
+type Job struct {
+	// Job ID
+	ID int `json:"jobId"`
+	// Status of the job
+	Status JobStatus `json:"status"`
+}
+
+// GetJobInput specifies which job to retrieve
+type GetJobInput struct {
+	// Name of the Java Cloud Service instance.
+	// Required.
+	ID string
+}
+
+// GetJob retrieves the job with the given id
+func (c *JobClient) GetJob(getInput *GetJobInput) (*Job, error) {
+	var job Job
+	if err := c.getResource(getInput.ID, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
+// WaitForJobCompletion waits for a service instance to be in the desired state
+func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeoutSeconds time.Duration) error {
+	return c.client.WaitFor("job to succeed", pollInterval, timeoutSeconds, func() (bool, error) {
+		info, getErr := c.GetJob(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("job ID is %v", info.ID))
+		switch s := info.Status; s {
+		case JobStatusSucceed: // Target State
+			c.client.DebugLogString("Job Succeeded")
+			return true, nil
+		case JobStatusFailed:
+			c.client.DebugLogString("Job Failed")
+			return false, fmt.Errorf("Job %q failed", input.ID)
+		case JobStatusRunning:
+			c.client.DebugLogString("Job Running")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown job state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1653,6 +1653,7 @@ type ScaleUpDownWLS struct {
 
 // ScaleUpDownServiceInstance scales the service instance up or down depending on the shape passed in.
 func (c *ServiceInstanceClient) ScaleUpDownServiceInstance(input *ScaleUpDownServiceInstanceInput) error {
+	var jobResponse JobResponse
 	if c.PollInterval == 0 {
 		c.PollInterval = waitForServiceInstanceReadyPollInterval
 	}
@@ -1660,21 +1661,17 @@ func (c *ServiceInstanceClient) ScaleUpDownServiceInstance(input *ScaleUpDownSer
 		c.Timeout = waitForServiceInstanceReadyTimeout
 	}
 
-	if err := c.updateResource(input.Name, serviceInstanceScaleUpDownPath, "POST", input); err != nil {
+	if err := c.updateResource(input.Name, serviceInstanceScaleUpDownPath, "POST", input, &jobResponse); err != nil {
 		return fmt.Errorf("unable to update Java Service Instance %q: %+v", input.Name, err)
 	}
 
-	// Call wait for instance ready now, as updating the instance is an eventually consistent operation.
-	getInput := &GetServiceInstanceInput{
-		Name: input.Name,
+	getJobInput := &GetJobInput{
+		ID: jobResponse.Details.JobID,
 	}
 
-	// Wait for the service instance to be running and return the result
-	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that.
-	serviceInstance, err := c.WaitForServiceInstanceState(getInput, ServiceInstanceLifecycleStateStart, c.PollInterval, c.Timeout)
-	// The service instance is returned as nil if it enters a terminating state.
-	if err != nil || serviceInstance == nil {
-		return fmt.Errorf("error creating service instance %q: %+v", input.Name, err)
+	err := c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return fmt.Errorf("error updating service instance %q: %+v", input.Name, err)
 	}
 
 	return nil
@@ -1717,6 +1714,7 @@ type DesiredStateHost struct {
 
 // UpdateDesiredState updates the specified desired state of a service instance
 func (c *ServiceInstanceClient) UpdateDesiredState(input *DesiredStateInput) error {
+	var jobResponse JobResponse
 	if c.PollInterval == 0 {
 		c.PollInterval = waitForServiceInstanceReadyPollInterval
 	}
@@ -1724,20 +1722,18 @@ func (c *ServiceInstanceClient) UpdateDesiredState(input *DesiredStateInput) err
 		c.Timeout = waitForServiceInstanceReadyTimeout
 	}
 
-	if err := c.updateResource(input.Name, fmt.Sprintf(serviceInstanceDesiredStatePath, input.LifecycleState), "POST", input); err != nil {
+	if err := c.updateResource(input.Name, fmt.Sprintf(serviceInstanceDesiredStatePath, input.LifecycleState), "POST", input, &jobResponse); err != nil {
 		return err
 	}
 
-	// Call wait for instance running now, as updating the instance is an eventually consistent operation
-	getInput := &GetServiceInstanceInput{
-		Name: input.Name,
+	getJobInput := &GetJobInput{
+		ID: jobResponse.Details.JobID,
 	}
 
-	// Wait for the service instance to be running and return the result
-	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
-	_, err := c.WaitForServiceInstanceState(getInput, input.LifecycleState, c.PollInterval, c.Timeout)
+	err := c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
 	if err != nil {
-		return fmt.Errorf("Error updating Service Instance %q: %+v", input.Name, err)
+		return fmt.Errorf("error updating service instance %q: %+v", input.Name, err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
This PR adds the ability to check the status of a job acting on a java service instance. So far this is only used for updating a service instance.

```
=== RUN   TestAccServiceInstanceLifeCycle_ScaleUp
--- PASS: TestAccServiceInstanceLifeCycle_ScaleUp (582.42s)
=== RUN   TestAccServiceInstanceLifeCycle_Stop
--- PASS: TestAccServiceInstanceLifeCycle_Stop (308.04s)
```