### PR TITLE
resolve issue parsing optional storage headers

### DIFF
--- a/storage/container.go
+++ b/storage/container.go
@@ -355,9 +355,5 @@ func (c *Client) success(rsp *http.Response, container *Container) (*Container, 
 		}
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	return container, nil
 }


### PR DESCRIPTION
Resolves issues with environments without Quotas where headers are not set.  Meta headers should be considered optional, removed fail on error.
