### PR TITLE
Add IP Reservations for PaaS Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To authenticate with the Oracle Compute Cloud the following credentials must be 
 - `OPC_STORAGE_ENDPOINT` - API Endpoint URL for the Object Storage Classic service (e.g. https://mydomain.storage.oraclecloud.com/\)
 - `OPC_LBAAS_ENDPOINT` - API Endpoint URL for the Load Balancer Classic service (e.g. https://lbcs-a123b3456c7896576655438.balancer.oraclecloud.com/\ )
 - `ORACLEPAAS_DATABASE_ENDPOINT` - API Endpoint URL for the Database Cloud service (e.g. https://dbaas.oraclecloud.com/\)
+- `ORACLEPAAS_MYSQL_ENDPOINT` - API Endpoint URL for the MySQL Cloud service (e.g. https://psm.us.oraclecloud.com/\)
 - `ORACLEPAAS_JAVA_ENDPOINT` - API Endpoint URL for the Java Cloud service (e.g. https://jaas.oraclecloud.com/\)
 - `ORACLEPAAS_APPLICATION_ENDPOINT` - API Endpoint URL for the Application Container Cloud service (e.g. https://apaas.us.oraclecloud.com/\)
 

--- a/database/ip_reservation.go
+++ b/database/ip_reservation.go
@@ -1,26 +1,51 @@
 package database
 
+import (
+	"fmt"
+	"time"
+)
+
 // API URI Paths for Container and Root objects
 const (
 	ipReservationContainerPath = "/paas/api/v1.1/network/%s/services/dbaas/ipreservations"
 	ipReservationResourcePath  = "/paas/api/v1.1/network/%s/services/dbaas/ipreservations/%s"
 )
 
+const waitForIPReservationReadyPollInterval = 1 * time.Second
+const waitForIPReservationReadyTimeout = 5 * time.Minute
+
+// IPReservationClient IP Reservation API Client
 type IPReservationClient struct {
 	IPReservationResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
 }
+
+// IPReservationStatus IP Reservation Status values
+type IPReservationStatus string
+
+const (
+	// IPReservationStatusInitializing Initializing
+	IPReservationStatusInitializing IPReservationStatus = "INITIALIZING"
+	// IPReservationStatusUnused Unused IP Reservation
+	IPReservationStatusUnused IPReservationStatus = "UNUSED"
+	// IPReservationStatusUsed Used IP Reservation
+	IPReservationStatusUsed IPReservationStatus = "USED"
+)
 
 // IPReservationClient obtains an new ResourceClient which can be used to access the
 // Database Cloud IP Reservation API
 func (c *Client) IPReservationClient() *IPReservationClient {
 	return &IPReservationClient{
-		IPReservationResourceClient{
+		IPReservationResourceClient: IPReservationResourceClient{
 			Client:           c,
 			ContainerPath:    ipReservationContainerPath,
 			ResourceRootPath: ipReservationResourcePath,
-		}}
+		},
+	}
 }
 
+// CreateIPReservationInput represents the Create IP Reservation API Request body
 type CreateIPReservationInput struct {
 	// Identity domain ID for the Database Cloud Service account
 	// For a Cloud account with Identity Cloud Service: the identity service ID, which has the form idcs-letters-and-numbers.
@@ -38,15 +63,52 @@ type CreateIPReservationInput struct {
 	Region string `json:"region"`
 }
 
+// CreateIPReservationInfo represents the Create IP Reservation API Response
+type CreateIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// DeleteIPReservationInfo represents the Delete IP Reservation API Response
+type DeleteIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// IPReservationInfo represents the Get IP Reservation API Response
 type IPReservationInfo struct {
-	ID                   int    `json:"id"`
-	Name                 string `json:"name"`
-	NetworkType          string `json:"networkType"`
-	Status               string `json:"status"`
-	IdentityDomain       string `json:"identityDomain"`
-	ServiceType          string `json:"serviceType"`
-	ComputeSiteName      string `json:"computeSiteName"`
+	// Id of the IP reservation.
+	ID int `json:"id"`
+	// Name of the IP reservation.
+	Name string `json:"name"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSiteName"`
+	// Name of the compute node using the IP reservation.
+	// This parameter is returned only when the IP reservation is in use.
+	Hostname string `json:"hostName"`
+	// The identity domain ID of the IP reservation.
+	IdentityDomain string `json:"identityDomain"`
+	// The public IP address for the IP reservation.
+	IPAddress string `json:"ipAddress"`
+	// Indicates whether the IP reservation is intended for instances attached to IP networks or the shared network.
+	NetworkType string `json:"networkType"`
+	// The service entitlement Id of Database Cloud Service within the Cloud account.
 	ServiceEntitlementID string `json:"serviceEntitlementId"`
+	// Name of the Database Cloud Service instance where the named IP reservation is used.
+	// This parameter is returned only when the IP reservation is in use.
+	ServiceName string `json:"serviceName"`
+	// The Service Type the IP Reservation is valid for. `DBaaS`.
+	ServiceType string `json:"serviceType"`
+	// Status of the IP reservation. Valid values: `INITIALIZING`, `UNUSED`, `USED`.
+	Status IPReservationStatus `json:"status"`
 }
 
 // IPReservations - used for the GET request that returns all reservations
@@ -54,33 +116,57 @@ type IPReservations struct {
 	IPReservations []IPReservationInfo `json:"ipReservations"`
 }
 
-// CreateServiceInstance creates a new ServiceInstace.
+// CreateIPReservation creates a new IP Reservation.
 func (c *IPReservationClient) CreateIPReservation(input *CreateIPReservationInput) (*IPReservationInfo, error) {
-	var ipReservation *IPReservationInfo
-	if err := c.createResource(input, ipReservation); err != nil {
+
+	if c.PollInterval == 0 {
+		c.PollInterval = waitForIPReservationReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = waitForIPReservationReadyTimeout
+	}
+
+	info, err := c.createResource(input)
+	if err != nil {
 		return nil, err
 	}
-	return ipReservation, nil
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IP Reservation %q: %+v", input.Name, err)
+	}
+
+	ipReservation, err := c.GetIPReservation(input.Name)
+	return ipReservation, err
 }
 
+// GetIPReservation get the details of an IP Reservation.
 func (c *IPReservationClient) GetIPReservation(name string) (*IPReservationInfo, error) {
-	var ipReservations *IPReservations
-	if err := c.getResource(name, ipReservations); err != nil {
+	info, err := c.getResource(name)
+	if err != nil {
 		return nil, err
 	}
-
-	// API returns all IP Reservations, iterate to find the one we want
-	for _, ipres := range ipReservations.IPReservations {
-		if ipres.Name == name {
-			return &ipres, nil
-		}
-	}
-	return nil, nil
+	return info, nil
 }
 
+// DeleteIPReservation deletes an IP Reservation.
 func (c *IPReservationClient) DeleteIPReservation(name string) error {
-	if err := c.deleteResource(name); err != nil {
+	info, err := c.deleteResource(name)
+	if err != nil {
 		return err
+	}
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return fmt.Errorf("error destroying IP Reservation %q: %+v", name, err)
 	}
 	return nil
 }

--- a/database/ip_reservation.go
+++ b/database/ip_reservation.go
@@ -155,6 +155,14 @@ func (c *IPReservationClient) GetIPReservation(name string) (*IPReservationInfo,
 
 // DeleteIPReservation deletes an IP Reservation.
 func (c *IPReservationClient) DeleteIPReservation(name string) error {
+
+	if c.PollInterval == 0 {
+		c.PollInterval = waitForIPReservationReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = waitForIPReservationReadyTimeout
+	}
+
 	info, err := c.deleteResource(name)
 	if err != nil {
 		return err

--- a/database/ip_reservation.go
+++ b/database/ip_reservation.go
@@ -1,0 +1,86 @@
+package database
+
+// API URI Paths for Container and Root objects
+const (
+	ipReservationContainerPath = "/paas/api/v1.1/network/%s/services/dbaas/ipreservations"
+	ipReservationResourcePath  = "/paas/api/v1.1/network/%s/services/dbaas/ipreservations/%s"
+)
+
+type IPReservationClient struct {
+	IPReservationResourceClient
+}
+
+// IPReservationClient obtains an new ResourceClient which can be used to access the
+// Database Cloud IP Reservation API
+func (c *Client) IPReservationClient() *IPReservationClient {
+	return &IPReservationClient{
+		IPReservationResourceClient{
+			Client:           c,
+			ContainerPath:    ipReservationContainerPath,
+			ResourceRootPath: ipReservationResourcePath,
+		}}
+}
+
+type CreateIPReservationInput struct {
+	// Identity domain ID for the Database Cloud Service account
+	// For a Cloud account with Identity Cloud Service: the identity service ID, which has the form idcs-letters-and-numbers.
+	// For a traditional cloud account: the name of the identity domain.
+	// Required
+	IdentityDomainID string
+	// Name of the IP reservation to create.
+	// Required
+	Name string `json:"ipResName"`
+	// Indicates whether the IP reservation is for instances attached to IP networks or the shared network
+	// set to `IPNetwork` for IP Network, or omit for shared network
+	NetworkType string `json:"networkType,omitempty"`
+	// Name of the region to create the IP reservation in
+	// Required
+	Region string `json:"region"`
+}
+
+type IPReservationInfo struct {
+	ID                   int    `json:"id"`
+	Name                 string `json:"name"`
+	NetworkType          string `json:"networkType"`
+	Status               string `json:"status"`
+	IdentityDomain       string `json:"identityDomain"`
+	ServiceType          string `json:"serviceType"`
+	ComputeSiteName      string `json:"computeSiteName"`
+	ServiceEntitlementID string `json:"serviceEntitlementId"`
+}
+
+// IPReservations - used for the GET request that returns all reservations
+type IPReservations struct {
+	IPReservations []IPReservationInfo `json:"ipReservations"`
+}
+
+// CreateServiceInstance creates a new ServiceInstace.
+func (c *IPReservationClient) CreateIPReservation(input *CreateIPReservationInput) (*IPReservationInfo, error) {
+	var ipReservation *IPReservationInfo
+	if err := c.createResource(input, ipReservation); err != nil {
+		return nil, err
+	}
+	return ipReservation, nil
+}
+
+func (c *IPReservationClient) GetIPReservation(name string) (*IPReservationInfo, error) {
+	var ipReservations *IPReservations
+	if err := c.getResource(name, ipReservations); err != nil {
+		return nil, err
+	}
+
+	// API returns all IP Reservations, iterate to find the one we want
+	for _, ipres := range ipReservations.IPReservations {
+		if ipres.Name == name {
+			return &ipres, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *IPReservationClient) DeleteIPReservation(name string) error {
+	if err := c.deleteResource(name); err != nil {
+		return err
+	}
+	return nil
+}

--- a/database/ip_reservation_resource_client.go
+++ b/database/ip_reservation_resource_client.go
@@ -32,8 +32,9 @@ func (c *IPReservationResourceClient) createResource(requestBody interface{}) (*
 
 func (c *IPReservationResourceClient) getResource(name string) (*IPReservationInfo, error) {
 	objectPath := c.getContainerPath(c.ContainerPath)
+	queryParams := "?networkType=ALL"
 
-	resp, err := c.executeRequest("GET", objectPath, nil)
+	resp, err := c.executeRequest("GET", objectPath+queryParams, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/database/ip_reservation_resource_client.go
+++ b/database/ip_reservation_resource_client.go
@@ -1,0 +1,88 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// IPReservationResourceClient is a client for the IP Reservation functions of the Database API.
+type IPReservationResourceClient struct {
+	*Client
+	ContainerPath    string
+	ResourceRootPath string
+}
+
+func (c *IPReservationResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+
+	return err
+}
+
+func (c *IPReservationResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.getContainerPath(c.ContainerPath)
+	}
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *IPReservationResourceClient) deleteResource(name string) error {
+	objectPath := c.getObjectPath(c.ResourceRootPath, name)
+
+	if _, err := c.executeRequest("DELETE", objectPath, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *IPReservationResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err = dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("Error decoding: %s\n%+v", err.Error(), resp)
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *IPReservationResourceClient) getContainerPath(root string) string {
+	// /paas/api/v1.1/network/{identityDomainId}/services/dbaas/ipreservations
+	return fmt.Sprintf(root, *c.client.IdentityDomain)
+}
+
+func (c *IPReservationResourceClient) getObjectPath(root, name string) string {
+	// /paas/api/v1.1/network/{identityDomainId}/services/dbaas/ipreservations/{ipResName}
+	return fmt.Sprintf(root, *c.client.IdentityDomain, name)
+}

--- a/database/ip_reservation_test.go
+++ b/database/ip_reservation_test.go
@@ -1,11 +1,11 @@
 package database
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/helper"
 	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccIPReservationLifeCycle(t *testing.T) {
@@ -17,23 +17,22 @@ func TestAccIPReservationLifeCycle(t *testing.T) {
 	}
 
 	ipReservation := CreateIPReservationInput{
-		Name: "test-ip-reservation",
+		Name:             "test-ip-reservation",
+		Region:           "uscom-central-1",
+		IdentityDomainID: *resClient.client.IdentityDomain,
 	}
 
 	_, err = resClient.CreateIPReservation(&ipReservation)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	defer destroyIPReservation(t, resClient, ipReservation.Name)
 
-	receivedRes, err := resClient.GetIPReservation(ipReservation.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if receivedRes.Name != ipReservation.Name {
-		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", ipReservation.Name, receivedRes.Name))
-	}
+	resp, err := resClient.GetIPReservation(ipReservation.Name)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ipReservation.Name, resp.Name, "IP Reservation Name should match")
+	assert.Equal(t, ipReservation.Region, resp.ComputeSiteName, "IP Reservation Compute Site Name should match region")
+	assert.Equal(t, ipReservation.IdentityDomainID, resp.IdentityDomain, "IP Reservation Identity Domain should match")
 
 }
 

--- a/database/ip_reservation_test.go
+++ b/database/ip_reservation_test.go
@@ -1,0 +1,53 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+func TestAccIPReservationLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	resClient, err := getIPResvervationClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipReservation := CreateIPReservationInput{
+		Name: "test-ip-reservation",
+	}
+
+	_, err = resClient.CreateIPReservation(&ipReservation)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer destroyIPReservation(t, resClient, ipReservation.Name)
+
+	receivedRes, err := resClient.GetIPReservation(ipReservation.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRes.Name != ipReservation.Name {
+		t.Fatal(fmt.Errorf("Names do not match. Wanted: %s Received: %s", ipReservation.Name, receivedRes.Name))
+	}
+
+}
+
+func getIPResvervationClient() (*IPReservationClient, error) {
+	client, err := GetDatabaseTestClient(&opc.Config{})
+	if err != nil {
+		return &IPReservationClient{}, err
+	}
+
+	return client.IPReservationClient(), nil
+}
+
+func destroyIPReservation(t *testing.T, client *IPReservationClient, name string) {
+	if err := client.DeleteIPReservation(name); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/database/jobs.go
+++ b/database/jobs.go
@@ -1,0 +1,109 @@
+package database
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for the Root Job path
+const (
+	JobRootPath = "/paas/api/v1.1/activitylog/%s/job/%s"
+)
+
+// Default Poll Interval value
+const waitForJobPollInterval = 1 * time.Second
+
+// JobClient is a client for the Service functions of the Job API.
+type JobClient struct {
+	ResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// Jobs returns a JobClient for checking job status
+func (c *Client) Jobs() *JobClient {
+	return &JobClient{
+		ResourceClient: ResourceClient{
+			Client:           c,
+			ResourceRootPath: JobRootPath,
+		},
+	}
+}
+
+// JobStatus defines the constants for the status of a job
+type JobStatus string
+
+const (
+	// JobStatusNew - the job is new.
+	JobStatusNew JobStatus = "NEW"
+	// JobStatusRunning - the job is still running.
+	JobStatusRunning JobStatus = "RUNNING"
+	// JobStatusFailed - the job has failed.
+	JobStatusFailed JobStatus = "FAILED"
+	// JobStatusSucceed - the job has succeeded.
+	JobStatusSucceed JobStatus = "SUCCEED"
+)
+
+// JobResponse details the job information received after submitting a request
+type JobResponse struct {
+	Details Details `json:"details"`
+}
+
+// Details details the attributes of the specific job that is running on the service instance
+type Details struct {
+	JobID   string `json:"jobId"`
+	Message string `json:"message"`
+}
+
+// Job details the attributes related to a job
+type Job struct {
+	// Job ID
+	ID int `json:"jobId"`
+	// Status of the job
+	Status JobStatus `json:"status"`
+}
+
+// GetJobInput specifies which job to retrieve
+type GetJobInput struct {
+	// ID of the job.
+	// Required.
+	ID string
+}
+
+// GetJob retrieves the job with the given id
+func (c *JobClient) GetJob(getInput *GetJobInput) (*Job, error) {
+	var job Job
+	if err := c.getResource(getInput.ID, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
+// WaitForJobCompletion waits for a service instance to be in the desired state
+func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeoutSeconds time.Duration) error {
+	return c.client.WaitFor("job to complete", pollInterval, timeoutSeconds, func() (bool, error) {
+		info, getErr := c.GetJob(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("job ID is %v", info.ID))
+		switch s := info.Status; s {
+		case JobStatusSucceed: // Target State
+			c.client.DebugLogString("Job Succeeded")
+			return true, nil
+		case JobStatusFailed:
+			c.client.DebugLogString("Job Failed")
+			return false, fmt.Errorf("Job %q failed", input.ID)
+		case JobStatusNew:
+			c.client.DebugLogString("Job New")
+			return false, nil
+		case JobStatusRunning:
+			c.client.DebugLogString("Job Running")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown job state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}

--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -348,7 +348,7 @@ type CreateServiceInstanceInput struct {
 	// A single IP reservation name or multiple IP reservation names separated by commas. Only IP reservations created in the specified region can be used.
 	// When IP reservations are used, all compute nodes of an instance must be provisioned with IP reservations, so the number of names in ipReservations must match the number of compute nodes in the service instance.
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Service level for the service instance
 	// Required.
 	Level ServiceInstanceLevel `json:"level"`

--- a/java/ip_reservation.go
+++ b/java/ip_reservation.go
@@ -1,0 +1,172 @@
+package java
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for Container and Root objects
+const (
+	ipReservationContainerPath = "/paas/api/v1.1/network/%s/services/jaas/ipreservations"
+	ipReservationResourcePath  = "/paas/api/v1.1/network/%s/services/jaas/ipreservations/%s"
+)
+
+const waitForIPReservationReadyPollInterval = 1 * time.Second
+const waitForIPReservationReadyTimeout = 5 * time.Minute
+
+// IPReservationClient IP Reservation API Client
+type IPReservationClient struct {
+	IPReservationResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// IPReservationStatus IP Reservation Status values
+type IPReservationStatus string
+
+const (
+	// IPReservationStatusInitializing Initializing
+	IPReservationStatusInitializing IPReservationStatus = "INITIALIZING"
+	// IPReservationStatusUnused Unused IP Reservation
+	IPReservationStatusUnused IPReservationStatus = "UNUSED"
+	// IPReservationStatusUsed Used IP Reservation
+	IPReservationStatusUsed IPReservationStatus = "USED"
+)
+
+// IPReservationClient obtains an new ResourceClient which can be used to access the
+// Database Cloud IP Reservation API
+func (c *Client) IPReservationClient() *IPReservationClient {
+	return &IPReservationClient{
+		IPReservationResourceClient: IPReservationResourceClient{
+			Client:           c,
+			ContainerPath:    ipReservationContainerPath,
+			ResourceRootPath: ipReservationResourcePath,
+		},
+	}
+}
+
+// CreateIPReservationInput represents the Create IP Reservation API Request body
+type CreateIPReservationInput struct {
+	// Identity domain ID for the Database Cloud Service account
+	// For a Cloud account with Identity Cloud Service: the identity service ID, which has the form idcs-letters-and-numbers.
+	// For a traditional cloud account: the name of the identity domain.
+	// Required
+	IdentityDomainID string
+	// Name of the IP reservation to create.
+	// Required
+	Name string `json:"ipResName"`
+	// Indicates whether the IP reservation is for instances attached to IP networks or the shared network
+	// set to `IPNetwork` for IP Network, or omit for shared network
+	NetworkType string `json:"networkType,omitempty"`
+	// Name of the region to create the IP reservation in
+	// Required
+	Region string `json:"region"`
+}
+
+// CreateIPReservationInfo represents the Create IP Reservation API Response
+type CreateIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// DeleteIPReservationInfo represents the Delete IP Reservation API Response
+type DeleteIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// IPReservationInfo represents the Get IP Reservation API Response
+type IPReservationInfo struct {
+	// Id of the IP reservation.
+	ID int `json:"id"`
+	// Name of the IP reservation.
+	Name string `json:"name"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSiteName"`
+	// Name of the compute node using the IP reservation.
+	// This parameter is returned only when the IP reservation is in use.
+	Hostname string `json:"hostName"`
+	// The identity domain ID of the IP reservation.
+	IdentityDomain string `json:"identityDomain"`
+	// The public IP address for the IP reservation.
+	IPAddress string `json:"ipAddress"`
+	// Indicates whether the IP reservation is intended for instances attached to IP networks or the shared network.
+	NetworkType string `json:"networkType"`
+	// The service entitlement Id of Database Cloud Service within the Cloud account.
+	ServiceEntitlementID string `json:"serviceEntitlementId"`
+	// Name of the Database Cloud Service instance where the named IP reservation is used.
+	// This parameter is returned only when the IP reservation is in use.
+	ServiceName string `json:"serviceName"`
+	// The Service Type the IP Reservation is valid for. `DBaaS`.
+	ServiceType string `json:"serviceType"`
+	// Status of the IP reservation. Valid values: `INITIALIZING`, `UNUSED`, `USED`.
+	Status IPReservationStatus `json:"status"`
+}
+
+// IPReservations - used for the GET request that returns all reservations
+type IPReservations struct {
+	IPReservations []IPReservationInfo `json:"ipReservations"`
+}
+
+// CreateIPReservation creates a new IP Reservation.
+func (c *IPReservationClient) CreateIPReservation(input *CreateIPReservationInput) (*IPReservationInfo, error) {
+
+	if c.PollInterval == 0 {
+		c.PollInterval = waitForIPReservationReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = waitForIPReservationReadyTimeout
+	}
+
+	info, err := c.createResource(input)
+	if err != nil {
+		return nil, err
+	}
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IP Reservation %q: %+v", input.Name, err)
+	}
+
+	ipReservation, err := c.GetIPReservation(input.Name)
+	return ipReservation, err
+}
+
+// GetIPReservation get the details of an IP Reservation.
+func (c *IPReservationClient) GetIPReservation(name string) (*IPReservationInfo, error) {
+	info, err := c.getResource(name)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// DeleteIPReservation deletes an IP Reservation.
+func (c *IPReservationClient) DeleteIPReservation(name string) error {
+	info, err := c.deleteResource(name)
+	if err != nil {
+		return err
+	}
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.Client.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return fmt.Errorf("error destroying IP Reservation %q: %+v", name, err)
+	}
+	return nil
+}

--- a/java/ip_reservation_resource_client.go
+++ b/java/ip_reservation_resource_client.go
@@ -1,0 +1,109 @@
+package java
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// IPReservationResourceClient is a client for the IP Reservation functions of the Java Cloud API.
+type IPReservationResourceClient struct {
+	*Client
+	ContainerPath    string
+	ResourceRootPath string
+}
+
+func (c *IPReservationResourceClient) createResource(requestBody interface{}) (*CreateIPReservationInfo, error) {
+	resp, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var info CreateIPReservationInfo
+	if err := c.unmarshalResponseBody(resp, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+func (c *IPReservationResourceClient) getResource(name string) (*IPReservationInfo, error) {
+	objectPath := c.getContainerPath(c.ContainerPath)
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipReservations IPReservations
+	if err := c.unmarshalResponseBody(resp, &ipReservations); err != nil {
+		return nil, err
+	}
+
+	// API returns all IP Reservations, iterate to find the one we want
+	for _, ipRes := range ipReservations.IPReservations {
+		if ipRes.Name == name {
+			var ipReservation *IPReservationInfo
+			ipReservation = &ipRes
+			return ipReservation, nil
+		}
+	}
+	return nil, fmt.Errorf("IP Reservation not found")
+}
+
+func (c *IPReservationResourceClient) deleteResource(name string) (*DeleteIPReservationInfo, error) {
+	objectPath := c.getObjectPath(c.ResourceRootPath, name)
+
+	resp, err := c.executeRequest("DELETE", objectPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var info DeleteIPReservationInfo
+	if err := c.unmarshalResponseBody(resp, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+func (c *IPReservationResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err = dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("Error decoding: %s\n%+v", err.Error(), resp)
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *IPReservationResourceClient) getContainerPath(root string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain)
+}
+
+func (c *IPReservationResourceClient) getObjectPath(root, name string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain, name)
+}

--- a/java/ip_reservation_test.go
+++ b/java/ip_reservation_test.go
@@ -1,0 +1,52 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIPReservationLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	resClient, err := getIPResvervationClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipReservation := CreateIPReservationInput{
+		Name:             "test-ip-reservation",
+		Region:           "uscom-central-1",
+		IdentityDomainID: *resClient.client.IdentityDomain,
+	}
+
+	_, err = resClient.CreateIPReservation(&ipReservation)
+	assert.NoError(t, err)
+
+	defer destroyIPReservation(t, resClient, ipReservation.Name)
+
+	resp, err := resClient.GetIPReservation(ipReservation.Name)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ipReservation.Name, resp.Name, "IP Reservation Name should match")
+	assert.Equal(t, ipReservation.Region, resp.ComputeSiteName, "IP Reservation Compute Site Name should match region")
+	assert.Equal(t, ipReservation.IdentityDomainID, resp.IdentityDomain, "IP Reservation Identity Domain should match")
+
+}
+
+func getIPResvervationClient() (*IPReservationClient, error) {
+	client, err := getJavaTestClient(&opc.Config{})
+	if err != nil {
+		return &IPReservationClient{}, err
+	}
+
+	return client.IPReservationClient(), nil
+}
+
+func destroyIPReservation(t *testing.T, client *IPReservationClient, name string) {
+	if err := client.DeleteIPReservation(name); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/java/jobs.go
+++ b/java/jobs.go
@@ -34,6 +34,8 @@ func (c *Client) Jobs() *JobClient {
 type JobStatus string
 
 const (
+	// JobStatusNew - the job is new.
+	JobStatusNew JobStatus = "NEW"
 	// JobStatusRunning - the job is still running.
 	JobStatusRunning JobStatus = "RUNNING"
 	// JobStatusFailed - the job has failed.
@@ -80,7 +82,7 @@ func (c *JobClient) GetJob(getInput *GetJobInput) (*Job, error) {
 
 // WaitForJobCompletion waits for a service instance to be in the desired state
 func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeoutSeconds time.Duration) error {
-	return c.client.WaitFor("job to succeed", pollInterval, timeoutSeconds, func() (bool, error) {
+	return c.client.WaitFor("job to complete", pollInterval, timeoutSeconds, func() (bool, error) {
 		info, getErr := c.GetJob(input)
 		if getErr != nil {
 			return false, getErr
@@ -93,6 +95,9 @@ func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeo
 		case JobStatusFailed:
 			c.client.DebugLogString("Job Failed")
 			return false, fmt.Errorf("Job %q failed", input.ID)
+		case JobStatusNew:
+			c.client.DebugLogString("Job New")
+			return false, nil
 		case JobStatusRunning:
 			c.client.DebugLogString("Job Running")
 			return false, nil

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1025,7 +1025,7 @@ type CreateOTD struct {
 	// IP reservations. See the My Oracle Support document titled How to Request Authorized IPs for Provisioning
 	// a Java Cloud Service with Database Exadata Cloud Service (MOS Note 2163568.1).
 	// Optional.
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Policy to use for routing requests to the load balancer. Valid policies include:
 	// Optional.
 	LoadBalancingPolicy ServiceInstanceLoadBalancingPolicy `json:"loadBalancingPolicy,omitempty"`
@@ -1201,7 +1201,7 @@ type CreateWLS struct {
 	// Support document titled How to Request Authorized IPs for Provisioning a Java Cloud Service with Database Exadata
 	// Cloud Service (MOS Note 2163568.1).
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// One or more Managed Server JVM arguments separated by a space.
 	// You cannot specify any arguments that are related to JVM heap sizes and PermGen spaces (for example, -Xms, -Xmx,
 	// -XX:PermSize, and -XX:MaxPermSize).

--- a/mysql/ip_reservation.go
+++ b/mysql/ip_reservation.go
@@ -1,0 +1,172 @@
+package mysql
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for Container and Root objects
+const (
+	ipReservationContainerPath = "/paas/api/v1.1/network/%s/services/MySQLCS/ipreservations"
+	ipReservationResourcePath  = "/paas/api/v1.1/network/%s/services/MySQLCS/ipreservations/%s"
+)
+
+const waitForIPReservationReadyPollInterval = 1 * time.Second
+const waitForIPReservationReadyTimeout = 5 * time.Minute
+
+// IPReservationClient IP Reservation API Client
+type IPReservationClient struct {
+	IPReservationResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// IPReservationStatus IP Reservation Status values
+type IPReservationStatus string
+
+const (
+	// IPReservationStatusInitializing Initializing
+	IPReservationStatusInitializing IPReservationStatus = "INITIALIZING"
+	// IPReservationStatusUnused Unused IP Reservation
+	IPReservationStatusUnused IPReservationStatus = "UNUSED"
+	// IPReservationStatusUsed Used IP Reservation
+	IPReservationStatusUsed IPReservationStatus = "USED"
+)
+
+// IPReservationClient obtains an new ResourceClient which can be used to access the
+// Database Cloud IP Reservation API
+func (c *MySQLClient) IPReservationClient() *IPReservationClient {
+	return &IPReservationClient{
+		IPReservationResourceClient: IPReservationResourceClient{
+			MySQLClient:      c,
+			ContainerPath:    ipReservationContainerPath,
+			ResourceRootPath: ipReservationResourcePath,
+		},
+	}
+}
+
+// CreateIPReservationInput represents the Create IP Reservation API Request body
+type CreateIPReservationInput struct {
+	// Identity domain ID for the Database Cloud Service account
+	// For a Cloud account with Identity Cloud Service: the identity service ID, which has the form idcs-letters-and-numbers.
+	// For a traditional cloud account: the name of the identity domain.
+	// Required
+	IdentityDomainID string
+	// Name of the IP reservation to create.
+	// Required
+	Name string `json:"ipResName"`
+	// Indicates whether the IP reservation is for instances attached to IP networks or the shared network
+	// set to `IPNetwork` for IP Network, or omit for shared network
+	NetworkType string `json:"networkType,omitempty"`
+	// Name of the region to create the IP reservation in
+	// Required
+	Region string `json:"region"`
+}
+
+// CreateIPReservationInfo represents the Create IP Reservation API Response
+type CreateIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// DeleteIPReservationInfo represents the Delete IP Reservation API Response
+type DeleteIPReservationInfo struct {
+	// Name of the IP reservation to create.
+	Name string `json:"ipResName"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSite"`
+	// Create IP Reservation Job ID
+	JobID string `json:"jobId"`
+}
+
+// IPReservationInfo represents the Get IP Reservation API Response
+type IPReservationInfo struct {
+	// Id of the IP reservation.
+	ID int `json:"id"`
+	// Name of the IP reservation.
+	Name string `json:"name"`
+	// Location (region) of the IP reservation.
+	ComputeSiteName string `json:"computeSiteName"`
+	// Name of the compute node using the IP reservation.
+	// This parameter is returned only when the IP reservation is in use.
+	Hostname string `json:"hostName"`
+	// The identity domain ID of the IP reservation.
+	IdentityDomain string `json:"identityDomain"`
+	// The public IP address for the IP reservation.
+	IPAddress string `json:"ipAddress"`
+	// Indicates whether the IP reservation is intended for instances attached to IP networks or the shared network.
+	NetworkType string `json:"networkType"`
+	// The service entitlement Id of Database Cloud Service within the Cloud account.
+	ServiceEntitlementID string `json:"serviceEntitlementId"`
+	// Name of the Database Cloud Service instance where the named IP reservation is used.
+	// This parameter is returned only when the IP reservation is in use.
+	ServiceName string `json:"serviceName"`
+	// The Service Type the IP Reservation is valid for. `DBaaS`.
+	ServiceType string `json:"serviceType"`
+	// Status of the IP reservation. Valid values: `INITIALIZING`, `UNUSED`, `USED`.
+	Status IPReservationStatus `json:"status"`
+}
+
+// IPReservations - used for the GET request that returns all reservations
+type IPReservations struct {
+	IPReservations []IPReservationInfo `json:"ipReservations"`
+}
+
+// CreateIPReservation creates a new IP Reservation.
+func (c *IPReservationClient) CreateIPReservation(input *CreateIPReservationInput) (*IPReservationInfo, error) {
+
+	if c.PollInterval == 0 {
+		c.PollInterval = waitForIPReservationReadyPollInterval
+	}
+	if c.Timeout == 0 {
+		c.Timeout = waitForIPReservationReadyTimeout
+	}
+
+	info, err := c.createResource(input)
+	if err != nil {
+		return nil, err
+	}
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.MySQLClient.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IP Reservation %q: %+v", input.Name, err)
+	}
+
+	ipReservation, err := c.GetIPReservation(input.Name)
+	return ipReservation, err
+}
+
+// GetIPReservation get the details of an IP Reservation.
+func (c *IPReservationClient) GetIPReservation(name string) (*IPReservationInfo, error) {
+	info, err := c.getResource(name)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// DeleteIPReservation deletes an IP Reservation.
+func (c *IPReservationClient) DeleteIPReservation(name string) error {
+	info, err := c.deleteResource(name)
+	if err != nil {
+		return err
+	}
+
+	getJobInput := &GetJobInput{
+		ID: info.JobID,
+	}
+
+	err = c.MySQLClient.Jobs().WaitForJobCompletion(getJobInput, c.PollInterval, c.Timeout)
+	if err != nil {
+		return fmt.Errorf("error destroying IP Reservation %q: %+v", name, err)
+	}
+	return nil
+}

--- a/mysql/ip_reservation_resource_client.go
+++ b/mysql/ip_reservation_resource_client.go
@@ -1,0 +1,109 @@
+package mysql
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// IPReservationResourceClient is a client for the IP Reservation functions of the Java Cloud API.
+type IPReservationResourceClient struct {
+	*MySQLClient
+	ContainerPath    string
+	ResourceRootPath string
+}
+
+func (c *IPReservationResourceClient) createResource(requestBody interface{}) (*CreateIPReservationInfo, error) {
+	resp, err := c.executeRequestWithContentType("POST", c.getContainerPath(c.ContainerPath), requestBody, "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	var info CreateIPReservationInfo
+	if err := c.unmarshalResponseBody(resp, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+func (c *IPReservationResourceClient) getResource(name string) (*IPReservationInfo, error) {
+	objectPath := c.getContainerPath(c.ContainerPath)
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipReservations IPReservations
+	if err := c.unmarshalResponseBody(resp, &ipReservations); err != nil {
+		return nil, err
+	}
+
+	// API returns all IP Reservations, iterate to find the one we want
+	for _, ipRes := range ipReservations.IPReservations {
+		if ipRes.Name == name {
+			var ipReservation *IPReservationInfo
+			ipReservation = &ipRes
+			return ipReservation, nil
+		}
+	}
+	return nil, fmt.Errorf("IP Reservation not found")
+}
+
+func (c *IPReservationResourceClient) deleteResource(name string) (*DeleteIPReservationInfo, error) {
+	objectPath := c.getObjectPath(c.ResourceRootPath, name)
+
+	resp, err := c.executeRequest("DELETE", objectPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var info DeleteIPReservationInfo
+	if err := c.unmarshalResponseBody(resp, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+func (c *IPReservationResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err = dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("Error decoding: %s\n%+v", err.Error(), resp)
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *IPReservationResourceClient) getContainerPath(root string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain)
+}
+
+func (c *IPReservationResourceClient) getObjectPath(root, name string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain, name)
+}

--- a/mysql/ip_reservation_test.go
+++ b/mysql/ip_reservation_test.go
@@ -1,0 +1,52 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/helper"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIPReservationLifeCycle(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
+	resClient, err := getIPResvervationClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipReservation := CreateIPReservationInput{
+		Name:             "test-ip-reservation",
+		Region:           "uscom-central-1",
+		IdentityDomainID: *resClient.client.IdentityDomain,
+	}
+
+	_, err = resClient.CreateIPReservation(&ipReservation)
+	assert.NoError(t, err)
+
+	defer destroyIPReservation(t, resClient, ipReservation.Name)
+
+	resp, err := resClient.GetIPReservation(ipReservation.Name)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ipReservation.Name, resp.Name, "IP Reservation Name should match")
+	assert.Equal(t, ipReservation.Region, resp.ComputeSiteName, "IP Reservation Compute Site Name should match region")
+	assert.Equal(t, ipReservation.IdentityDomainID, resp.IdentityDomain, "IP Reservation Identity Domain should match")
+
+}
+
+func getIPResvervationClient() (*IPReservationClient, error) {
+	client, err := GetMySQLTestClient(&opc.Config{})
+	if err != nil {
+		return &IPReservationClient{}, err
+	}
+
+	return client.IPReservationClient(), nil
+}
+
+func destroyIPReservation(t *testing.T, client *IPReservationClient, name string) {
+	if err := client.DeleteIPReservation(name); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/mysql/jobs.go
+++ b/mysql/jobs.go
@@ -1,0 +1,109 @@
+package mysql
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for the Root Job path
+const (
+	JobRootPath = "/paas/api/v1.1/activitylog/%s/job/%s"
+)
+
+// Default Poll Interval value
+const waitForJobPollInterval = 1 * time.Second
+
+// JobClient is a client for the Service functions of the Job API.
+type JobClient struct {
+	ResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// Jobs returns a JobClient for checking job status
+func (c *MySQLClient) Jobs() *JobClient {
+	return &JobClient{
+		ResourceClient: ResourceClient{
+			MySQLClient:      c,
+			ResourceRootPath: JobRootPath,
+		},
+	}
+}
+
+// JobStatus defines the constants for the status of a job
+type JobStatus string
+
+const (
+	// JobStatusNew - the job is new.
+	JobStatusNew JobStatus = "NEW"
+	// JobStatusRunning - the job is still running.
+	JobStatusRunning JobStatus = "RUNNING"
+	// JobStatusFailed - the job has failed.
+	JobStatusFailed JobStatus = "FAILED"
+	// JobStatusSucceed - the job has succeeded.
+	JobStatusSucceed JobStatus = "SUCCEED"
+)
+
+// JobResponse details the job information received after submitting a request
+type JobResponse struct {
+	Details Details `json:"details"`
+}
+
+// Details details the attributes of the specific job that is running on the service instance
+type Details struct {
+	JobID   string `json:"jobId"`
+	Message string `json:"message"`
+}
+
+// Job details the attributes related to a job
+type Job struct {
+	// Job ID
+	ID int `json:"jobId"`
+	// Status of the job
+	Status JobStatus `json:"status"`
+}
+
+// GetJobInput specifies which job to retrieve
+type GetJobInput struct {
+	// ID of the job.
+	// Required.
+	ID string
+}
+
+// GetJob retrieves the job with the given id
+func (c *JobClient) GetJob(getInput *GetJobInput) (*Job, error) {
+	var job Job
+	if err := c.getResource(getInput.ID, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
+// WaitForJobCompletion waits for a service instance to be in the desired state
+func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeoutSeconds time.Duration) error {
+	return c.client.WaitFor("job to complete", pollInterval, timeoutSeconds, func() (bool, error) {
+		info, getErr := c.GetJob(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("job ID is %v", info.ID))
+		switch s := info.Status; s {
+		case JobStatusSucceed: // Target State
+			c.client.DebugLogString("Job Succeeded")
+			return true, nil
+		case JobStatusFailed:
+			c.client.DebugLogString("Job Failed")
+			return false, fmt.Errorf("Job %q failed", input.ID)
+		case JobStatusNew:
+			c.client.DebugLogString("Job New")
+			return false, nil
+		case JobStatusRunning:
+			c.client.DebugLogString("Job Running")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown job state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}


### PR DESCRIPTION
Adds SDK support for the PaaS Services IP Reservation APIs:

- [Database Cloud Service IP Reservations](https://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/api-ip-reservations.html)
- [MySQL Cloud Service IP Reservations](https://docs.oracle.com/cloud/latest/mysql-cloud/CSMCS/api-ip-reservations.html)
- [Java Cloud Service IP Reservations](https://docs.oracle.com/en/cloud/paas/java-cloud/jsrmr/api-ip-reservations.html)