### PR TITLE
Fix retry logic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -235,7 +237,23 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 	var statusCode int
 	var errMessage string
 
-	for i := 0; i < retries; i++ {
+	// Cache the body content for retries.
+	// This is to allow reuse of the original request for the retries attempts
+	// as the act of reading the body (when doing the httpClient.Do()) closes the
+	// Reader.
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initial sleep time between retries
+	sleep := 1 * time.Second
+
+	for i := retries; i > 0; i-- {
+
+		// replace body with new unread Reader before each request
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			return resp, err
@@ -245,17 +263,27 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 			return resp, nil
 		}
 
+		// replace body with unread Reader
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
 		buf := new(bytes.Buffer)
 		_, err = buf.ReadFrom(resp.Body)
 		if err != nil {
 			return resp, err
 		}
-		method := req.Method
-		url := req.URL
 		errMessage = buf.String()
 		statusCode = resp.StatusCode
-		c.DebugLogString(fmt.Sprintf("%s %s Encountered HTTP (%d) Error: %s", method, url, statusCode, errMessage))
-		c.DebugLogString(fmt.Sprintf("%d/%d retries left", i+1, retries))
+		c.DebugLogString(fmt.Sprintf("%s %s Encountered HTTP (%d) Error: %s", req.Method, req.URL, statusCode, errMessage))
+		if i != 1 {
+			c.DebugLogString(fmt.Sprintf("%d of %d retries remaining. Next retry in %ds", i-1, retries, sleep/time.Second))
+			time.Sleep(sleep)
+			// increase sleep time for next retry (exponential backoff with jitter)
+			// up to a maximum of ~60 seconds
+			if sleep <= 30*time.Second {
+				jitter := time.Duration(rand.Int63n(int64(sleep))) / 2
+				sleep = (sleep * 2) + jitter
+			}
+		}
 	}
 
 	oracleErr := &opc.OracleError{

--- a/client/client.go
+++ b/client/client.go
@@ -241,18 +241,23 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 	// This is to allow reuse of the original request for the retries attempts
 	// as the act of reading the body (when doing the httpClient.Do()) closes the
 	// Reader.
-	body, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	// Initial sleep time between retries
 	sleep := 1 * time.Second
 
 	for i := retries; i > 0; i-- {
 
 		// replace body with new unread Reader before each request
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		if len(body) > 0 {
+			req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		}
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -262,9 +267,6 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 			return resp, nil
 		}
-
-		// replace body with unread Reader
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 		buf := new(bytes.Buffer)
 		_, err = buf.ReadFrom(resp.Body)

--- a/database/access_rules_test.go
+++ b/database/access_rules_test.go
@@ -122,6 +122,8 @@ func TestAccAccessRulesLifeCycle(t *testing.T) {
 }
 
 func TestGetDefaultAccessRule_Basic(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
 	sClient, aClient, err := getAccessRulesTestClients()
 	if err != nil {
 		t.Fatal(err)
@@ -168,6 +170,8 @@ func TestGetDefaultAccessRule_Basic(t *testing.T) {
 }
 
 func TestUpdateDefaultAccessRule_Basic(t *testing.T) {
+	helper.Test(t, helper.TestCase{})
+
 	sClient, aClient, err := getAccessRulesTestClients()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR address an issue identified https://github.com/terraform-providers/terraform-provider-opc/issues/148 where the retries always fail for requests the Body (POST/PUT) as the body of the request in unreadable after

This update also adds an exponential backoff to the retries, with a 60 second maximum delay.