### PR TITLE
Fix dbcs/jcs IP Reservations attribute type

### DIFF
--- a/database/service_instance.go
+++ b/database/service_instance.go
@@ -348,7 +348,7 @@ type CreateServiceInstanceInput struct {
 	// A single IP reservation name or multiple IP reservation names separated by commas. Only IP reservations created in the specified region can be used.
 	// When IP reservations are used, all compute nodes of an instance must be provisioned with IP reservations, so the number of names in ipReservations must match the number of compute nodes in the service instance.
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Service level for the service instance
 	// Required.
 	Level ServiceInstanceLevel `json:"level"`

--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1025,7 +1025,7 @@ type CreateOTD struct {
 	// IP reservations. See the My Oracle Support document titled How to Request Authorized IPs for Provisioning
 	// a Java Cloud Service with Database Exadata Cloud Service (MOS Note 2163568.1).
 	// Optional.
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Policy to use for routing requests to the load balancer. Valid policies include:
 	// Optional.
 	LoadBalancingPolicy ServiceInstanceLoadBalancingPolicy `json:"loadBalancingPolicy,omitempty"`
@@ -1201,7 +1201,7 @@ type CreateWLS struct {
 	// Support document titled How to Request Authorized IPs for Provisioning a Java Cloud Service with Database Exadata
 	// Cloud Service (MOS Note 2163568.1).
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// One or more Managed Server JVM arguments separated by a space.
 	// You cannot specify any arguments that are related to JVM heap sizes and PermGen spaces (for example, -Xms, -Xmx,
 	// -XX:PermSize, and -XX:MaxPermSize).


### PR DESCRIPTION
SDK update to address  https://github.com/terraform-providers/terraform-provider-oraclepaas/issues/45

Updates the database service and java service IP Reservations attributes type from []string to string as the API takes a single string with a comma separated list of IP Reservations names, not a list of strings.
