### PR TITLE
fix username format to work with IDCS Cloud Accounts

### DIFF
--- a/storage/storage_client.go
+++ b/storage/storage_client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const strAccount = "/Storage-%s"
-const strUsername = "/Storage-%s:%s"
+const strUsername = "Storage-%s:%s"
 const authHeader = "X-Auth-Token"
 const strQualifiedName = "%s%s/%s"
 const apiVersion = "v1"


### PR DESCRIPTION
This small fix removes the leading `/` in cloud account username that was causing a issue with authentication for IDCS Cloud Accounts but worked with Traditional accounts.  Without the leading '/' authentication is successful for both Traditional and IDCS Cloud accounts.

Tests run against a Traditional Account:

```
$ make testacc TEST=./storage
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./storage  -timeout 120m
=== RUN   TestAccObtainAuthenticationToken
--- PASS: TestAccObtainAuthenticationToken (1.26s)
=== RUN   TestAccContainerLifeCycle
--- PASS: TestAccContainerLifeCycle (4.64s)
=== RUN   Test_isCustomHeader
--- PASS: Test_isCustomHeader (0.23s)
=== RUN   Test_updateOrRemoveHeadersStringValue
--- PASS: Test_updateOrRemoveHeadersStringValue (0.21s)
=== RUN   Test_updateOrRemoveHeadersIntValue
--- PASS: Test_updateOrRemoveHeadersIntValue (0.23s)
=== RUN   TestAccObjectLifeCycle_contentSource
--- PASS: TestAccObjectLifeCycle_contentSource (3.52s)
=== RUN   TestAccObjectLifeCycle_fileSource
--- PASS: TestAccObjectLifeCycle_fileSource (3.79s)
=== RUN   TestAccObjectLifeCycle_contentSourceID
--- PASS: TestAccObjectLifeCycle_contentSourceID (3.71s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/storage	17.608s
```

Tests run against a IDCS Cloud Account:

```
$ make testacc TEST=./storage
==> Checking that code complies with gofmt requirements...
ORACLE_ACC=1 go test -v ./storage  -timeout 120m
=== RUN   TestAccObtainAuthenticationToken
--- PASS: TestAccObtainAuthenticationToken (0.40s)
=== RUN   TestAccContainerLifeCycle
--- PASS: TestAccContainerLifeCycle (4.65s)
=== RUN   Test_isCustomHeader
--- PASS: Test_isCustomHeader (0.24s)
=== RUN   Test_updateOrRemoveHeadersStringValue
--- PASS: Test_updateOrRemoveHeadersStringValue (0.26s)
=== RUN   Test_updateOrRemoveHeadersIntValue
--- PASS: Test_updateOrRemoveHeadersIntValue (0.23s)
=== RUN   TestAccObjectLifeCycle_contentSource
--- PASS: TestAccObjectLifeCycle_contentSource (3.34s)
=== RUN   TestAccObjectLifeCycle_fileSource
--- PASS: TestAccObjectLifeCycle_fileSource (3.12s)
=== RUN   TestAccObjectLifeCycle_contentSourceID
--- PASS: TestAccObjectLifeCycle_contentSourceID (3.69s)
PASS
ok  	github.com/hashicorp/go-oracle-terraform/storage	15.955s
```
