### PR TITLE
Update vpn_endpoint_v2.go

### DIFF
--- a/compute/vpn_endpoint_v2.go
+++ b/compute/vpn_endpoint_v2.go
@@ -265,7 +265,7 @@ type UpdateVPNEndpointV2Input struct {
 	// Required
 	CustomerVPNGateway string `json:"customer_vpn_gateway"`
 	// Description of the VPNGatewayV2
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	// Enable/Disable the tunnel
 	// Optional
 	Enabled bool `json:"enabled"`


### PR DESCRIPTION
The API doesn't like when you submit an empty description string so we're adding `omitempty` to combat this