### PR TITLE
Update service_instance.go

### DIFF
--- a/java/service_instance.go
+++ b/java/service_instance.go
@@ -1238,8 +1238,8 @@ type CreateWLS struct {
 	// 	deployment for your Oracle Java Cloud Service instance on Oracle Cloud Infrastructure.
 	//
 	// 	An Oracle Database Cloud Service database deployment based on a RAC database is also not supported.
-	// Required
-	DBServiceName string `json:"dbServiceName"`
+	// Optional
+	DBServiceName string `json:"dbServiceName,omitempty"`
 	// Mode of the domain. Valid values include: DEVELOPMENT and PRODUCTION. The default value is PRODUCTION.
 	// Optional
 	DomainMode ServiceInstanceDomainMode `json:"domainMode,omitempty"`


### PR DESCRIPTION
Removing the required part of DBServiceName to allow for java service instances to be provisioned with oci databases