### PR TITLE
Feature: Specify cross user resource

### DIFF
--- a/compute/compute_client.go
+++ b/compute/compute_client.go
@@ -124,6 +124,18 @@ func (c *Client) getUnqualifiedName(name string) string {
 	}
 
 	nameParts := strings.Split(name, "/")
+
+	if len(nameParts) < 4 {
+		return name
+	}
+
+	// OCI-Classic allows users to specify resources from across different users. We'll check to see if
+	// a user uses a different username and return the orginal if it's different.
+	userName := fmt.Sprintf("/%s/%s", nameParts[1], nameParts[2])
+	if userName != c.getUserName() {
+		return name
+	}
+
 	return strings.Join(nameParts[3:], "/")
 }
 

--- a/compute/instances_integration_test.go
+++ b/compute/instances_integration_test.go
@@ -16,7 +16,7 @@ const (
 	_InstanceTestLabel      = "test"
 	_InstanceTestShape      = "oc3"
 	_InstanceTestImage      = "/oracle/public/OL_7.2_UEKR4_x86_64"
-	_InstanceTestImageEntry = 4
+	_InstanceTestImageEntry = 6
 	_InstanceTestPublicPool = "ippool:/oracle/public/ippool"
 )
 


### PR DESCRIPTION
This PR allows users to specify resource names from across users by not un-qualifying the resource name if a different username or identity domain is specified. 