### PR TITLE
fix crash when instance nat attribute is "null" string

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -765,7 +765,7 @@ func (c *InstancesClient) unqualifyNetworking(info map[string]NetworkingInfo) (m
 		if v.Vnic != "" {
 			unq.Vnic = c.getUnqualifiedName(v.Vnic)
 		}
-		if v.Nat != nil {
+		if v.Nat != nil && len(v.Nat) > 0 && v.Nat[0] != "null" {
 			unq.Nat, err = c.unqualifyNat(v.Nat)
 			if err != nil {
 				return nil, err
@@ -806,7 +806,7 @@ func (c *InstancesClient) unqualifyNat(nat []string) ([]string, error) {
 			continue
 		}
 		n := strings.Split(v, ":")
-		if len(n) < 1 {
+		if len(n) < 2 {
 			return nil, fmt.Errorf("Error unqualifying NAT: %s", v)
 		}
 		u := n[1]


### PR DESCRIPTION
This fix resolves a crash with the terraform-provider-opc when the instance details return `nat: "null"` rather than `null` or a list which has been observed in some cases after a host crash. The crash with terraform provider prevents restarting the failed instance.  

```
  "networking": {
    "eth0": {
      "model": "e1000",
      "seclists": [
        "/Compute-a123456/user@example.com/oraclemigration"
      ],
      "dns": [
        "oraclemigration.compute-a123456.oraclecloud.internal."
      ],
      "vethernet": "/oracle/public/default",
      "nat": "null"
    }
  },
```